### PR TITLE
Add configurable grid_cell_count and range filtering parameters

### DIFF
--- a/cube_bathymetry/src/cube_bathymetry_node.cpp
+++ b/cube_bathymetry/src/cube_bathymetry_node.cpp
@@ -53,7 +53,10 @@ public:
     declare_parameter("cell_size", 1.0);
     double cell_size = get_parameter("cell_size").as_double();
 
-    map_sheet_ = std::make_shared<cube::MapSheet>(cube::CellCounts(5), cube::CellSizes(cell_size));
+    declare_parameter("grid_cell_count", 25);
+    int grid_cell_count = get_parameter("grid_cell_count").as_int();
+
+    map_sheet_ = std::make_shared<cube::MapSheet>(cube::CellCounts(grid_cell_count), cube::CellSizes(cell_size));
 
     tf_buffer_ = std::make_unique<tf2_ros::Buffer>(get_clock());
     tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, this);

--- a/cube_bathymetry/src/detections_to_pointcloud.cpp
+++ b/cube_bathymetry/src/detections_to_pointcloud.cpp
@@ -45,6 +45,18 @@ public:
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_configure(const rclcpp_lifecycle::State &state)
   {
+    if(!has_parameter("minimum_range"))
+    {
+      declare_parameter("minimum_range", minimum_range_);
+    }
+    minimum_range_ = get_parameter("minimum_range").as_double();
+
+    if(!has_parameter("maximum_range"))
+    {
+      declare_parameter("maximum_range", maximum_range_);
+    }
+    maximum_range_ = get_parameter("maximum_range").as_double();
+
     detections_subscriber_ = create_subscription<marine_acoustic_msgs::msg::SonarDetections>(
       "detections",
       rclcpp::SensorDataQoS(),
@@ -136,6 +148,22 @@ private:
 
     auto soundings =error_model_->compute(*msg, platform);
 
+    std::vector<cube::Sounding> filtered_soundings;
+    filtered_soundings.reserve(soundings.size());
+    for(const auto& sounding : soundings)
+    {
+      double range = sqrt(
+        sounding.sonar_relative_position.x * sounding.sonar_relative_position.x +
+        sounding.sonar_relative_position.y * sounding.sonar_relative_position.y +
+        sounding.sonar_relative_position.z * sounding.sonar_relative_position.z
+      );
+      if(range >= minimum_range_ && range <= maximum_range_)
+      {
+        filtered_soundings.push_back(sounding);
+      }
+    }
+    soundings = std::move(filtered_soundings);
+
     sensor_msgs::msg::PointCloud2 pointcloud;
     pointcloud.header = msg->header;
 
@@ -192,6 +220,9 @@ private:
   rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::PointCloud2>::SharedPtr pointcloud_publisher_;
 
   std::shared_ptr<cube::ErrorModel> error_model_;
+
+  double minimum_range_ = 0.0; // meters
+  double maximum_range_ = 12000.0; // meters
 
 };
 


### PR DESCRIPTION
## Summary

Uncommitted local changes from field work (Oct 2025) found during workspace migration from the old `project11/jazzy` layout to `ros2_agent_workspace`.

**Changes in this branch:**
- **`cube_bathymetry_node.cpp`**: Make `grid_cell_count` a ROS parameter (was hardcoded to 5, now defaults to 25)
- **`detections_to_pointcloud.cpp`**: Add `minimum_range` (default 0.0m) and `maximum_range` (default 12000.0m) parameters for sounding range filtering

These are **new features not present upstream** — they make the cube_bathymetry node more configurable for field use.

## Investigation needed before merging

- This branch is based on `ab58d38`, but upstream `jazzy` has since had PR #2 merged (header fixes, TASK-020). A rebase is needed.
- The rebase should be clean since PR #2 touched different areas (headers) than these changes (parameters and filtering logic).
- Verify the `grid_cell_count` default of 25 (vs original hardcoded 5) is appropriate.
- Test range filtering behavior with real sonar data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)