### PR TITLE
perf: optimize range filtering and add debug logging

### DIFF
--- a/cube_bathymetry/src/detections_to_pointcloud.cpp
+++ b/cube_bathymetry/src/detections_to_pointcloud.cpp
@@ -50,12 +50,14 @@ public:
       declare_parameter("minimum_range", minimum_range_);
     }
     minimum_range_ = get_parameter("minimum_range").as_double();
+    minimum_range_sq_ = minimum_range_ * minimum_range_;
 
     if(!has_parameter("maximum_range"))
     {
       declare_parameter("maximum_range", maximum_range_);
     }
     maximum_range_ = get_parameter("maximum_range").as_double();
+    maximum_range_sq_ = maximum_range_ * maximum_range_;
 
     detections_subscriber_ = create_subscription<marine_acoustic_msgs::msg::SonarDetections>(
       "detections",
@@ -152,15 +154,20 @@ private:
     filtered_soundings.reserve(soundings.size());
     for(const auto& sounding : soundings)
     {
-      double range = sqrt(
+      double range_sq =
         sounding.sonar_relative_position.x * sounding.sonar_relative_position.x +
         sounding.sonar_relative_position.y * sounding.sonar_relative_position.y +
-        sounding.sonar_relative_position.z * sounding.sonar_relative_position.z
-      );
-      if(range >= minimum_range_ && range <= maximum_range_)
+        sounding.sonar_relative_position.z * sounding.sonar_relative_position.z;
+      if(range_sq >= minimum_range_sq_ && range_sq <= maximum_range_sq_)
       {
         filtered_soundings.push_back(sounding);
       }
+    }
+    auto filtered_count = soundings.size() - filtered_soundings.size();
+    if(filtered_count > 0)
+    {
+      RCLCPP_DEBUG_STREAM_THROTTLE(get_logger(), *get_clock(), 10000,
+        filtered_count << " of " << soundings.size() << " soundings filtered by range");
     }
     soundings = std::move(filtered_soundings);
 
@@ -222,7 +229,9 @@ private:
   std::shared_ptr<cube::ErrorModel> error_model_;
 
   double minimum_range_ = 0.0; // meters
+  double minimum_range_sq_ = 0.0;
   double maximum_range_ = 12000.0; // meters
+  double maximum_range_sq_ = 12000.0 * 12000.0;
 
 };
 

--- a/cube_bathymetry/src/detections_to_pointcloud.cpp
+++ b/cube_bathymetry/src/detections_to_pointcloud.cpp
@@ -229,9 +229,9 @@ private:
   std::shared_ptr<cube::ErrorModel> error_model_;
 
   double minimum_range_ = 0.0; // meters
-  double minimum_range_sq_ = 0.0;
+  double minimum_range_sq_ = minimum_range_ * minimum_range_;
   double maximum_range_ = 12000.0; // meters
-  double maximum_range_sq_ = 12000.0 * 12000.0;
+  double maximum_range_sq_ = maximum_range_ * maximum_range_;
 
 };
 


### PR DESCRIPTION
## Summary

- Replace `sqrt()` with squared-distance comparison in range filtering loop to avoid unnecessary square root computation per sounding
- Add `minimum_range_sq_` and `maximum_range_sq_` member variables, computed once in `on_configure()`
- Add throttled `RCLCPP_DEBUG_STREAM_THROTTLE` logging (10s interval) when soundings are filtered by range

Closes #8

## Test plan

- [x] `colcon build --packages-select cube_bathymetry` compiles cleanly
- [ ] Verify at runtime that range filtering behavior is unchanged (squared comparison is mathematically equivalent for non-negative ranges)
- [ ] Set log level to DEBUG and confirm filtered-sounding messages appear when expected

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
