### PR TITLE
fix: correct variance dilution and truncate quotient formula

### DIFF
--- a/cube_bathymetry/src/node.cpp
+++ b/cube_bathymetry/src/node.cpp
@@ -115,7 +115,7 @@ bool Node::insert(double distance, const Sounding& sounding, const Parameters& p
   distance += CONF_95PC * std::sqrt(sounding.horizontal_error);
 
   float offset = 0.0;
-  double variance = sounding.vertical_error*(1.0 + parameters.stddev_to_confidence_interval_scale*pow(distance, parameters.distance_exponent));
+  double variance = sounding.vertical_error*(1.0 + parameters.variance_scale*pow(distance, parameters.distance_exponent));
 
 
   // if (sounding.range != 0.0 && predicted_depth_  != parameters.no_data_value)
@@ -216,7 +216,7 @@ void Node::truncate(const Parameters & parameters)
   }
   ssd -= mean*mean/(n+1);
   mean /= (n+1);
-  float ssd_k = n*ssd/(n*n+1);
+  float ssd_k = n*ssd/(n*n-1);
 
   /* Run the list computing quotients; outliers are removed from the queue.
    */


### PR DESCRIPTION
## Summary

- Fix variance dilution in `Node::insert()`: use `variance_scale` (computed from grid spacing via `pow(dist_scale, -dist_exp)`) instead of `stddev_to_confidence_interval_scale` (1.96 CI multiplier) which has no physical relationship to distance-based variance dilution
- Fix Eeg outlier quotient formula in `Node::truncate()`: correct denominator from `n*n+1` to `n*n-1`, matching the original CUBE implementation's `n²-1 = (n-1)(n+1)`

Both issues were found by comparing the new C++ implementation against the original CUBE C source.

Closes #11
Closes #12

## Test plan

- [ ] Verify build succeeds
- [ ] Run unit tests (pending #17)
- [ ] Compare algorithm output against original CUBE for known test cases

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
