### PR TITLE
test: add unit test suite for CUBE algorithm core

### DIFF
--- a/cube_bathymetry/CMakeLists.txt
+++ b/cube_bathymetry/CMakeLists.txt
@@ -114,6 +114,23 @@ install(TARGETS bag_to_geotiff
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+
+  ament_add_gtest(test_hypothesis test/test_hypothesis.cpp)
+  target_link_libraries(test_hypothesis cube_bathymetry)
+
+  ament_add_gtest(test_node test/test_node.cpp)
+  target_link_libraries(test_node cube_bathymetry)
+
+  ament_add_gtest(test_parameters test/test_parameters.cpp)
+  target_link_libraries(test_parameters cube_bathymetry)
+
+  ament_add_gtest(test_grid test/test_grid.cpp)
+  target_link_libraries(test_grid cube_bathymetry)
+
+  ament_add_gtest(test_map_sheet test/test_map_sheet.cpp)
+  target_link_libraries(test_map_sheet cube_bathymetry)
 endif()
 
 ament_export_dependencies(rclcpp)

--- a/cube_bathymetry/include/cube_bathymetry/common.h
+++ b/cube_bathymetry/include/cube_bathymetry/common.h
@@ -31,7 +31,7 @@ namespace cube
 {
 
 static constexpr double CONF_95PC = 1.96; /* Scale for 95% CI on Unit Normal */
-static constexpr double CONF_99PC = 2.95; /* Scale for 99% CI on Unit Normal */
+static constexpr double CONF_99PC = 2.576; /* Scale for 99% CI on Unit Normal */
 
 static constexpr float INVALID_DATA = std::numeric_limits<float>::max();
 

--- a/cube_bathymetry/package.xml
+++ b/cube_bathymetry/package.xml
@@ -23,6 +23,7 @@
   <depend>tf2_ros</depend>
   <depend>tf2_sensor_msgs</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/cube_bathymetry/src/node.cpp
+++ b/cube_bathymetry/src/node.cpp
@@ -172,7 +172,7 @@ bool Node::queueEstimate(float depth, float variance, const Parameters & paramet
 DepthAndUncertainty Node::extractDepthAndUncertainty(const Parameters & parameters)
 {
   if(nominated_hypothesis_)
-    return {nominated_hypothesis_->current_estimate, parameters.stddev_to_confidence_interval_scale*std::sqrt(nominated_hypothesis_->current_variance)};
+    return {nominated_hypothesis_->current_estimate, parameters.stddev_to_confidence_interval_scale*std::sqrt(nominated_hypothesis_->input_sample_variance)};
 
   auto h = chooseHypothesis();
 
@@ -181,8 +181,8 @@ DepthAndUncertainty Node::extractDepthAndUncertainty(const Parameters & paramete
     if(h->number_of_samples > 0)
     {
       float depth = h->current_estimate;
-      float variance = parameters.stddev_to_confidence_interval_scale*std::sqrt(h->current_variance);
-      return {depth, variance};
+      float uncertainty = parameters.stddev_to_confidence_interval_scale*std::sqrt(h->input_sample_variance);
+      return {depth, uncertainty};
     }
   }
   
@@ -240,12 +240,28 @@ void Node::queueFlush(const Parameters & parameters)
 
   truncate(parameters);
 
-  while(!queue_.empty())
-  {
-    auto mi = queue_.begin();
-    advance(mi, queue_.size()/2);
-    update(mi->depth, mi->uncertainty, parameters);
-    queue_.erase(mi);
+  // Copy to vector for indexed access (original uses array indices)
+  std::vector<DepthAndUncertainty> q(queue_.begin(), queue_.end());
+  queue_.clear();
+
+  int n = q.size();
+  int ex_pt, direction, scale = 1;
+
+  if ((n % 2) == 0) {
+    // Even: start just left of center, go right first
+    ex_pt = n / 2 - 1;
+    direction = +1;
+  } else {
+    // Odd: start at center, go left first
+    ex_pt = n / 2;
+    direction = -1;
+  }
+
+  while (ex_pt >= 0) {
+    update(q[ex_pt].depth, q[ex_pt].uncertainty, parameters);
+    ex_pt += direction * scale;
+    direction = -direction;
+    scale++;
   }
 
 }

--- a/cube_bathymetry/src/node.cpp
+++ b/cube_bathymetry/src/node.cpp
@@ -204,6 +204,9 @@ std::shared_ptr<Hypothesis> Node::chooseHypothesis()
 
 void Node::truncate(const Parameters & parameters)
 {
+  if(queue_.size() < 3)
+    return;
+
   float mean = 0.0;
   float ssd = 0.0;
   auto n = queue_.size()-1;

--- a/cube_bathymetry/test/test_grid.cpp
+++ b/cube_bathymetry/test/test_grid.cpp
@@ -1,0 +1,160 @@
+// Copyright 2025 Center for Coastal and Ocean Mapping and NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+#include "cube_bathymetry/grid.h"
+#include <cmath>
+
+namespace cube
+{
+
+class GridTest : public ::testing::Test
+{
+protected:
+  Parameters params{CellSizes(1.0f), "order1a"};
+};
+
+TEST_F(GridTest, ConstructorSetsProperties)
+{
+  CellCounts counts(10, 10);
+  CellSizes sizes(1.0f);
+  MapPosition origin(100.0, 200.0);
+
+  Grid g(counts, sizes, origin, params);
+
+  EXPECT_EQ(g.cellCounts().x, 10);
+  EXPECT_EQ(g.cellCounts().y, 10);
+  EXPECT_DOUBLE_EQ(g.cellSizes().x, 1.0);
+  EXPECT_DOUBLE_EQ(g.cellSizes().y, 1.0);
+  EXPECT_DOUBLE_EQ(g.origin().x, 100.0);
+  EXPECT_DOUBLE_EQ(g.origin().y, 200.0);
+}
+
+TEST_F(GridTest, BoundsCorrect)
+{
+  CellCounts counts(10, 20);
+  CellSizes sizes(0.5f);
+  MapPosition origin(0.0, 0.0);
+
+  Grid g(counts, sizes, origin, params);
+  auto b = g.bounds();
+
+  EXPECT_DOUBLE_EQ(b.minimum.x, 0.0);
+  EXPECT_DOUBLE_EQ(b.minimum.y, 0.0);
+  EXPECT_DOUBLE_EQ(b.maximum.x, 5.0);
+  EXPECT_DOUBLE_EQ(b.maximum.y, 10.0);
+}
+
+TEST_F(GridTest, ValuesInitiallyNaN)
+{
+  CellCounts counts(5, 5);
+  CellSizes sizes(1.0f);
+  MapPosition origin(0.0, 0.0);
+
+  Grid g(counts, sizes, origin, params);
+  auto vals = g.values();
+
+  EXPECT_EQ(vals.size(), 25u);
+  for (const auto& v : vals) {
+    EXPECT_TRUE(std::isnan(v.depth));
+  }
+}
+
+TEST_F(GridTest, InsertSingleSounding)
+{
+  CellCounts counts(10, 10);
+  CellSizes sizes(1.0f);
+  MapPosition origin(0.0, 0.0);
+
+  Grid g(counts, sizes, origin, params);
+
+  MapSounding s(5.0, 5.0, -10.0f);
+  s.sounding.vertical_error = 0.5f;
+  s.sounding.horizontal_error = 0.1f;
+
+  EXPECT_TRUE(g.insert(s));
+}
+
+TEST_F(GridTest, InsertMultipleSoundingsProducesDepth)
+{
+  CellCounts counts(10, 10);
+  CellSizes sizes(1.0f);
+  MapPosition origin(0.0, 0.0);
+
+  Grid g(counts, sizes, origin, params);
+
+  // Insert many consistent soundings at the center
+  for (int i = 0; i < 20; ++i) {
+    MapSounding s(5.0, 5.0, -10.0f);
+    s.sounding.vertical_error = 0.5f;
+    s.sounding.horizontal_error = 0.1f;
+    g.insert(s);
+  }
+
+  auto vals = g.values();
+
+  // At least some nodes should have non-NaN values
+  bool found_valid = false;
+  for (const auto& v : vals) {
+    if (!std::isnan(v.depth)) {
+      found_valid = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found_valid);
+}
+
+TEST_F(GridTest, InsertOutsideGridReturnsFalse)
+{
+  CellCounts counts(10, 10);
+  CellSizes sizes(1.0f);
+  MapPosition origin(0.0, 0.0);
+
+  Grid g(counts, sizes, origin, params);
+
+  // Sounding far outside the grid
+  MapSounding s(100.0, 100.0, -10.0f);
+  s.sounding.vertical_error = 0.5f;
+  s.sounding.horizontal_error = 0.1f;
+
+  EXPECT_FALSE(g.insert(s));
+}
+
+TEST_F(GridTest, InsertVectorOfSoundings)
+{
+  CellCounts counts(10, 10);
+  CellSizes sizes(1.0f);
+  MapPosition origin(0.0, 0.0);
+
+  Grid g(counts, sizes, origin, params);
+
+  std::vector<MapSounding> soundings;
+  for (int i = 0; i < 5; ++i) {
+    MapSounding s(5.0, 5.0, -10.0f);
+    s.sounding.vertical_error = 0.5f;
+    s.sounding.horizontal_error = 0.1f;
+    soundings.push_back(s);
+  }
+
+  EXPECT_TRUE(g.insert(soundings));
+}
+
+}  // namespace cube

--- a/cube_bathymetry/test/test_grid.cpp
+++ b/cube_bathymetry/test/test_grid.cpp
@@ -22,6 +22,7 @@
 #include <gtest/gtest.h>
 #include "cube_bathymetry/grid.h"
 #include <cmath>
+#include <vector>
 
 namespace cube
 {

--- a/cube_bathymetry/test/test_hypothesis.cpp
+++ b/cube_bathymetry/test/test_hypothesis.cpp
@@ -1,0 +1,187 @@
+// Copyright 2025 Center for Coastal and Ocean Mapping and NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+#include "cube_bathymetry/hypothesis.h"
+#include "cube_bathymetry/parameters.h"
+#include <cmath>
+
+namespace cube
+{
+
+class HypothesisTest : public ::testing::Test
+{
+protected:
+  // Default parameters with 1m grid
+  Parameters params{CellSizes(1.0f), "order1a"};
+};
+
+TEST_F(HypothesisTest, ConstructorInitializesCorrectly)
+{
+  Hypothesis h(10.0f, 0.5f);
+
+  EXPECT_DOUBLE_EQ(h.current_estimate, 10.0);
+  EXPECT_DOUBLE_EQ(h.current_variance, 0.5);
+  EXPECT_DOUBLE_EQ(h.predicted_estimate, 10.0);
+  EXPECT_DOUBLE_EQ(h.predicted_variance, 0.5);
+  EXPECT_EQ(h.number_of_samples, 1u);
+  EXPECT_DOUBLE_EQ(h.cumulative_bayes_factor, 1.0);
+  EXPECT_EQ(h.sequence_length, 0u);
+}
+
+TEST_F(HypothesisTest, NullHypothesisHasZeroSamples)
+{
+  auto h = Hypothesis::generateNullHypothesis(10.0f, 0.5f);
+
+  EXPECT_DOUBLE_EQ(h->current_estimate, 10.0);
+  EXPECT_DOUBLE_EQ(h->current_variance, 0.5);
+  EXPECT_EQ(h->number_of_samples, 0u);
+}
+
+TEST_F(HypothesisTest, ResetMonitorRestoresDefaults)
+{
+  Hypothesis h(10.0f, 0.5f);
+  h.cumulative_bayes_factor = 0.05;
+  h.sequence_length = 3;
+
+  h.resetMonitor();
+
+  EXPECT_DOUBLE_EQ(h.cumulative_bayes_factor, 1.0);
+  EXPECT_EQ(h.sequence_length, 0u);
+}
+
+TEST_F(HypothesisTest, UpdateWithConsistentDataSucceeds)
+{
+  Hypothesis h(10.0f, 1.0f);
+
+  // Update with data close to the current estimate
+  bool result = h.update(10.1f, 1.0f, params);
+
+  EXPECT_TRUE(result);
+  EXPECT_EQ(h.number_of_samples, 2u);
+  // Estimate should move toward the new observation
+  EXPECT_GT(h.current_estimate, 10.0);
+  EXPECT_LT(h.current_estimate, 10.1);
+  // Variance should decrease with more data
+  EXPECT_LT(h.current_variance, 1.0);
+}
+
+TEST_F(HypothesisTest, UpdateKalmanFilterEquations)
+{
+  // Verify the Kalman filter update equations match W&H DLM
+  Hypothesis h(10.0f, 1.0f);
+
+  float depth = 12.0f;
+  float variance = 2.0f;
+
+  // With discount=1.0 (default), system variance = 0
+  // predicted_variance = current_variance + 0 = current_variance
+  // gain = pred_var / (obs_var + pred_var)
+  double expected_gain = 1.0 / (2.0 + 1.0);
+  double expected_innovation = 12.0 - 10.0;
+  double expected_estimate = 10.0 + expected_gain * expected_innovation;
+  double expected_cur_var = 2.0 * 1.0 / (2.0 + 1.0);
+
+  bool result = h.update(depth, variance, params);
+  EXPECT_TRUE(result);
+
+  EXPECT_NEAR(h.current_estimate, expected_estimate, 1e-10);
+  EXPECT_NEAR(h.current_variance, expected_cur_var, 1e-10);
+}
+
+TEST_F(HypothesisTest, UpdateWithOutlierTriggersIntervention)
+{
+  Hypothesis h(10.0f, 0.01f);  // Very tight variance
+
+  // Data far from estimate should trigger intervention
+  bool result = h.update(50.0f, 0.01f, params);
+
+  EXPECT_FALSE(result);
+  // Sample count should not increase on failed update
+  EXPECT_EQ(h.number_of_samples, 1u);
+}
+
+TEST_F(HypothesisTest, MonitorDetectsSingleOutlier)
+{
+  Hypothesis h(10.0f, 0.1f);
+
+  // Large deviation relative to forecast variance
+  bool result = h.monitor(100.0f, 0.1f, params);
+
+  EXPECT_FALSE(result);
+}
+
+TEST_F(HypothesisTest, MonitorAcceptsConsistentData)
+{
+  Hypothesis h(10.0f, 1.0f);
+
+  // Small deviation relative to forecast variance
+  bool result = h.monitor(10.5f, 1.0f, params);
+
+  EXPECT_TRUE(result);
+}
+
+TEST_F(HypothesisTest, MonitorDetectsDriftByRunlength)
+{
+  Hypothesis h(10.0f, 1.0f);
+
+  // Feed slightly off data repeatedly to trigger runlength failure
+  // With est_offset=4.0, bayes_fac_t=0.135, runlength_t=5
+  // We need cumulative Bayes factor to drop below threshold
+  // or sequence length to exceed threshold
+  bool last_result = true;
+  for (int i = 0; i < 20; ++i) {
+    // Moderate outlier that individually passes but cumulatively fails
+    last_result = h.monitor(10.0f + 3.0f * std::sqrt(2.0f), 1.0f, params);
+    if (!last_result) break;
+  }
+  // Should eventually detect drift
+  EXPECT_FALSE(last_result);
+}
+
+TEST_F(HypothesisTest, InputSampleVarianceTracked)
+{
+  Hypothesis h(10.0f, 1.0f);
+  EXPECT_FLOAT_EQ(h.input_sample_variance, 0.0f);
+
+  h.update(10.5f, 1.0f, params);
+
+  // After one update, sample variance should be non-zero
+  // since the new depth differs from the estimate
+  EXPECT_GT(h.input_sample_variance, 0.0f);
+}
+
+TEST_F(HypothesisTest, MultipleUpdatesConverge)
+{
+  Hypothesis h(10.0f, 10.0f);  // Start with high uncertainty
+
+  // Feed consistent data at 12.0m
+  for (int i = 0; i < 50; ++i) {
+    h.update(12.0f, 0.5f, params);
+  }
+
+  // Should converge close to 12.0
+  EXPECT_NEAR(h.current_estimate, 12.0, 0.1);
+  // Variance should be small
+  EXPECT_LT(h.current_variance, 0.5);
+}
+
+}  // namespace cube

--- a/cube_bathymetry/test/test_map_sheet.cpp
+++ b/cube_bathymetry/test/test_map_sheet.cpp
@@ -1,0 +1,145 @@
+// Copyright 2025 Center for Coastal and Ocean Mapping and NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+#include "cube_bathymetry/map_sheet.h"
+#include <cmath>
+
+namespace cube
+{
+
+class MapSheetTest : public ::testing::Test
+{
+protected:
+  CellCounts counts{10, 10};
+  CellSizes sizes{1.0f};
+};
+
+TEST_F(MapSheetTest, ConstructorSetsProperties)
+{
+  MapSheet ms(counts, sizes, "order1a");
+
+  EXPECT_DOUBLE_EQ(ms.cellSizes().x, 1.0);
+  EXPECT_DOUBLE_EQ(ms.cellSizes().y, 1.0);
+  EXPECT_EQ(ms.cellCountsPerGrid().x, 10);
+  EXPECT_EQ(ms.cellCountsPerGrid().y, 10);
+}
+
+TEST_F(MapSheetTest, InitiallyNoGrids)
+{
+  MapSheet ms(counts, sizes);
+  EXPECT_TRUE(ms.grids().empty());
+}
+
+TEST_F(MapSheetTest, AddSoundingsCreatesGrids)
+{
+  MapSheet ms(counts, sizes);
+
+  std::vector<MapSounding> soundings;
+  for (int i = 0; i < 5; ++i) {
+    MapSounding s(5.0, 5.0, -10.0f);
+    s.sounding.vertical_error = 0.5f;
+    s.sounding.horizontal_error = 0.1f;
+    soundings.push_back(s);
+  }
+
+  ms.addSoundings(soundings);
+  EXPECT_FALSE(ms.grids().empty());
+}
+
+TEST_F(MapSheetTest, AddEmptySoundingsNoOp)
+{
+  MapSheet ms(counts, sizes);
+  std::vector<MapSounding> soundings;
+
+  ms.addSoundings(soundings);
+  EXPECT_TRUE(ms.grids().empty());
+}
+
+TEST_F(MapSheetTest, GetOrCreateGridsCreatesOnDemand)
+{
+  MapSheet ms(counts, sizes);
+
+  MapBounds bounds(MapPosition(0.0, 0.0), MapPosition(5.0, 5.0));
+  auto grids = ms.getOrCreateGridsIn(bounds);
+
+  EXPECT_FALSE(grids.empty());
+}
+
+TEST_F(MapSheetTest, GridIndexComputation)
+{
+  MapSheet ms(counts, sizes);
+
+  // With 10x10 cells at 1m, grid size is 10x10m
+  auto idx = ms.gridIndex(MapPosition(5.0, 5.0));
+  EXPECT_EQ(idx.x, 0);
+  EXPECT_EQ(idx.y, 0);
+
+  auto idx2 = ms.gridIndex(MapPosition(15.0, 25.0));
+  EXPECT_EQ(idx2.x, 1);
+  EXPECT_EQ(idx2.y, 2);
+}
+
+TEST_F(MapSheetTest, NegativeCoordinateGridIndex)
+{
+  MapSheet ms(counts, sizes);
+
+  auto idx = ms.gridIndex(MapPosition(-5.0, -5.0));
+  EXPECT_EQ(idx.x, -1);
+  EXPECT_EQ(idx.y, -1);
+}
+
+TEST_F(MapSheetTest, GridBoundsExpandWithData)
+{
+  MapSheet ms(counts, sizes);
+
+  std::vector<MapSounding> soundings;
+  MapSounding s(5.0, 5.0, -10.0f);
+  s.sounding.vertical_error = 0.5f;
+  s.sounding.horizontal_error = 0.1f;
+  soundings.push_back(s);
+
+  ms.addSoundings(soundings);
+
+  auto bounds = ms.gridBounds();
+  EXPECT_TRUE(valid(bounds));
+}
+
+TEST_F(MapSheetTest, SpreadSoundingsCreateMultipleGrids)
+{
+  MapSheet ms(counts, sizes);
+
+  std::vector<MapSounding> soundings;
+  // Soundings in different grid tiles
+  for (int i = 0; i < 3; ++i) {
+    MapSounding s(i * 15.0, i * 15.0, -10.0f);
+    s.sounding.vertical_error = 0.5f;
+    s.sounding.horizontal_error = 0.1f;
+    soundings.push_back(s);
+  }
+
+  ms.addSoundings(soundings);
+
+  // Should have created multiple grids
+  EXPECT_GT(ms.grids().size(), 1u);
+}
+
+}  // namespace cube

--- a/cube_bathymetry/test/test_map_sheet.cpp
+++ b/cube_bathymetry/test/test_map_sheet.cpp
@@ -22,6 +22,7 @@
 #include <gtest/gtest.h>
 #include "cube_bathymetry/map_sheet.h"
 #include <cmath>
+#include <vector>
 
 namespace cube
 {

--- a/cube_bathymetry/test/test_node.cpp
+++ b/cube_bathymetry/test/test_node.cpp
@@ -74,11 +74,13 @@ TEST_F(NodeTest, UpdateWithOutlierCreatesNewHypothesis)
   // Very different depth with tight variance triggers intervention
   n.update(50.0f, 0.01f, params);
 
-  // Should now have two hypotheses
+  // Should now have two hypotheses; chosen one should not be
+  // near the midpoint, confirming they are separate hypotheses
   auto chosen = n.chooseHypothesis();
   ASSERT_NE(chosen, nullptr);
-  // The chosen one has the most samples (1 each), so either could be chosen
-  // but we should have at least one hypothesis
+  EXPECT_TRUE(
+    std::abs(chosen->current_estimate - 10.0) < 1.0 ||
+    std::abs(chosen->current_estimate - 50.0) < 1.0);
 }
 
 TEST_F(NodeTest, ChooseHypothesisPicksMostSamples)
@@ -141,11 +143,14 @@ TEST_F(NodeTest, ExtractDepthAndUncertaintyNoData)
 TEST_F(NodeTest, ExtractDepthAndUncertaintyWithData)
 {
   Node n;
+  // Need multiple updates with varying depths so input_sample_variance > 0
   n.update(10.0f, 1.0f, params);
+  n.update(10.5f, 1.0f, params);
+  n.update(9.5f, 1.0f, params);
 
   auto result = n.extractDepthAndUncertainty(params);
   EXPECT_FALSE(std::isnan(result.depth));
-  EXPECT_NEAR(result.depth, 10.0, 0.1);
+  EXPECT_NEAR(result.depth, 10.0, 0.5);
   EXPECT_FALSE(std::isnan(result.uncertainty));
   EXPECT_GT(result.uncertainty, 0.0);
 }

--- a/cube_bathymetry/test/test_node.cpp
+++ b/cube_bathymetry/test/test_node.cpp
@@ -1,0 +1,183 @@
+// Copyright 2025 Center for Coastal and Ocean Mapping and NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+#include "cube_bathymetry/node.h"
+#include <cmath>
+
+namespace cube
+{
+
+class NodeTest : public ::testing::Test
+{
+protected:
+  Parameters params{CellSizes(1.0f), "order1a"};
+};
+
+TEST_F(NodeTest, AddHypothesisSucceeds)
+{
+  Node n;
+  EXPECT_TRUE(n.addHypothesis(10.0f, 1.0f));
+}
+
+TEST_F(NodeTest, BestHypothesisReturnsNullWhenEmpty)
+{
+  Node n;
+  auto h = n.bestHypothesis(10.0f, 1.0f);
+  EXPECT_EQ(h, nullptr);
+}
+
+TEST_F(NodeTest, BestHypothesisFindsClosest)
+{
+  Node n;
+  n.addHypothesis(10.0f, 1.0f);
+  n.addHypothesis(20.0f, 1.0f);
+
+  auto h = n.bestHypothesis(11.0f, 1.0f);
+  ASSERT_NE(h, nullptr);
+  EXPECT_NEAR(h->current_estimate, 10.0, 1e-6);
+}
+
+TEST_F(NodeTest, UpdateCreatesHypothesisWhenEmpty)
+{
+  Node n;
+  EXPECT_TRUE(n.update(10.0f, 1.0f, params));
+
+  auto h = n.chooseHypothesis();
+  ASSERT_NE(h, nullptr);
+  EXPECT_NEAR(h->current_estimate, 10.0, 1e-6);
+}
+
+TEST_F(NodeTest, UpdateWithOutlierCreatesNewHypothesis)
+{
+  Node n;
+  n.update(10.0f, 0.01f, params);
+
+  // Very different depth with tight variance triggers intervention
+  n.update(50.0f, 0.01f, params);
+
+  // Should now have two hypotheses
+  auto chosen = n.chooseHypothesis();
+  ASSERT_NE(chosen, nullptr);
+  // The chosen one has the most samples (1 each), so either could be chosen
+  // but we should have at least one hypothesis
+}
+
+TEST_F(NodeTest, ChooseHypothesisPicksMostSamples)
+{
+  Node n;
+  n.addHypothesis(10.0f, 1.0f);
+  n.addHypothesis(20.0f, 1.0f);
+
+  // Update with data near first hypothesis multiple times
+  for (int i = 0; i < 5; ++i) {
+    n.update(10.1f, 1.0f, params);
+  }
+
+  auto h = n.chooseHypothesis();
+  ASSERT_NE(h, nullptr);
+  EXPECT_NEAR(h->current_estimate, 10.0, 0.5);
+}
+
+TEST_F(NodeTest, QueueEstimateMedianFilter)
+{
+  Node n;
+  // Fill beyond median_length (default=11) to push data through
+  for (int i = 0; i < 15; ++i) {
+    n.queueEstimate(10.0f + i * 0.1f, 1.0f, params);
+  }
+
+  // After exceeding median_length, data should have been pushed through
+  // Then flush remaining
+  n.queueFlush(params);
+
+  auto h = n.chooseHypothesis();
+  ASSERT_NE(h, nullptr);
+}
+
+TEST_F(NodeTest, QueueFlushProcessesAllData)
+{
+  Node n;
+  // Add some data to the queue (less than median_length)
+  for (int i = 0; i < 5; ++i) {
+    n.queueEstimate(10.0f, 1.0f, params);
+  }
+
+  // Queue should have data but not yet pushed through
+  // Flush should process it
+  n.queueFlush(params);
+
+  auto h = n.chooseHypothesis();
+  ASSERT_NE(h, nullptr);
+  EXPECT_NEAR(h->current_estimate, 10.0, 0.1);
+}
+
+TEST_F(NodeTest, ExtractDepthAndUncertaintyNoData)
+{
+  Node n;
+  auto result = n.extractDepthAndUncertainty(params);
+  EXPECT_TRUE(std::isnan(result.depth));
+  EXPECT_TRUE(std::isnan(result.uncertainty));
+}
+
+TEST_F(NodeTest, ExtractDepthAndUncertaintyWithData)
+{
+  Node n;
+  n.update(10.0f, 1.0f, params);
+
+  auto result = n.extractDepthAndUncertainty(params);
+  EXPECT_FALSE(std::isnan(result.depth));
+  EXPECT_NEAR(result.depth, 10.0, 0.1);
+  EXPECT_FALSE(std::isnan(result.uncertainty));
+  EXPECT_GT(result.uncertainty, 0.0);
+}
+
+TEST_F(NodeTest, TruncateRemovesOutliers)
+{
+  Node n;
+  // Add consistent data and one outlier via the queue
+  for (int i = 0; i < 10; ++i) {
+    n.queueEstimate(10.0f, 0.1f, params);
+  }
+  // Add an outlier
+  n.queueEstimate(100.0f, 0.1f, params);
+
+  // Flush should apply truncation
+  n.queueFlush(params);
+
+  auto h = n.chooseHypothesis();
+  ASSERT_NE(h, nullptr);
+  // Result should be near 10.0, not pulled toward the outlier
+  EXPECT_NEAR(h->current_estimate, 10.0, 1.0);
+}
+
+TEST_F(NodeTest, MultipleConsistentUpdatesConverge)
+{
+  Node n;
+  for (int i = 0; i < 20; ++i) {
+    n.update(15.0f, 0.5f, params);
+  }
+
+  auto result = n.extractDepthAndUncertainty(params);
+  EXPECT_NEAR(result.depth, 15.0, 0.1);
+}
+
+}  // namespace cube

--- a/cube_bathymetry/test/test_parameters.cpp
+++ b/cube_bathymetry/test/test_parameters.cpp
@@ -1,0 +1,129 @@
+// Copyright 2025 Center for Coastal and Ocean Mapping and NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+#include "cube_bathymetry/parameters.h"
+#include <cmath>
+#include <stdexcept>
+
+namespace cube
+{
+
+TEST(ParametersTest, Order1aDefaults)
+{
+  Parameters p(CellSizes(1.0f), "order1a");
+
+  // IHO Order 1a: fixed=0.5 (squared), percent=0.013 (squared)
+  EXPECT_DOUBLE_EQ(p.iho_fixed, 0.5 * 0.5);
+  EXPECT_DOUBLE_EQ(p.iho_percent, 0.013 * 0.013);
+  EXPECT_EQ(p.iho_order, "order1a");
+}
+
+TEST(ParametersTest, ExclusiveOrder)
+{
+  Parameters p(CellSizes(1.0f), "exclusive");
+
+  EXPECT_DOUBLE_EQ(p.iho_fixed, 0.15 * 0.15);
+  EXPECT_DOUBLE_EQ(p.iho_percent, 0.0075 * 0.0075);
+}
+
+TEST(ParametersTest, SpecialOrder)
+{
+  Parameters p(CellSizes(1.0f), "special");
+
+  EXPECT_DOUBLE_EQ(p.iho_fixed, 0.25 * 0.25);
+  EXPECT_DOUBLE_EQ(p.iho_percent, 0.0075 * 0.0075);
+}
+
+TEST(ParametersTest, Order1b)
+{
+  Parameters p(CellSizes(1.0f), "order1b");
+
+  // Same as order1a
+  EXPECT_DOUBLE_EQ(p.iho_fixed, 0.5 * 0.5);
+  EXPECT_DOUBLE_EQ(p.iho_percent, 0.013 * 0.013);
+}
+
+TEST(ParametersTest, Order2)
+{
+  Parameters p(CellSizes(1.0f), "order2");
+
+  EXPECT_DOUBLE_EQ(p.iho_fixed, 1.0 * 1.0);
+  EXPECT_DOUBLE_EQ(p.iho_percent, 0.023 * 0.023);
+}
+
+TEST(ParametersTest, UnknownOrderThrows)
+{
+  EXPECT_THROW(Parameters(CellSizes(1.0f), "invalid"), std::invalid_argument);
+}
+
+TEST(ParametersTest, GridResolutionDistanceScale)
+{
+  // distance_scale should equal the cell size (square cells)
+  Parameters p(CellSizes(2.0f));
+  EXPECT_DOUBLE_EQ(p.distance_scale, 2.0);
+
+  Parameters p2(CellSizes(5.0f));
+  EXPECT_DOUBLE_EQ(p2.distance_scale, 5.0);
+}
+
+TEST(ParametersTest, GridResolutionVarianceScale)
+{
+  // variance_scale = distance_scale^(-distance_exponent)
+  // With 1m grid: distance_scale=1.0, distance_exponent=2.0
+  // variance_scale = 1.0^(-2.0) = 1.0
+  Parameters p(CellSizes(1.0f));
+  EXPECT_DOUBLE_EQ(p.variance_scale, 1.0);
+
+  // With 2m grid: distance_scale=2.0
+  // variance_scale = 2.0^(-2.0) = 0.25
+  Parameters p2(CellSizes(2.0f));
+  EXPECT_DOUBLE_EQ(p2.variance_scale, 0.25);
+}
+
+TEST(ParametersTest, ContextSearchRange)
+{
+  // min_context = 5.0 / distance_scale
+  // max_context = 10.0 / distance_scale
+  Parameters p(CellSizes(2.0f));
+  EXPECT_DOUBLE_EQ(p.minimum_context_search_range, 5.0 / 2.0);
+  EXPECT_DOUBLE_EQ(p.maximum_context_search_range, 10.0 / 2.0);
+}
+
+TEST(ParametersTest, DefaultParameterValues)
+{
+  Parameters p(CellSizes(1.0f));
+
+  EXPECT_EQ(p.median_length, 11u);
+  EXPECT_FLOAT_EQ(p.quotient_limit, 30.0f);
+  EXPECT_FLOAT_EQ(p.discount, 1.0f);
+  EXPECT_FLOAT_EQ(p.estimate_offset, 4.0f);
+  EXPECT_FLOAT_EQ(p.bayes_factor_threshold, 0.135f);
+  EXPECT_EQ(p.runlength_threshold, 5u);
+  EXPECT_FLOAT_EQ(p.stddev_to_confidence_interval_scale, 1.96f);
+  EXPECT_FLOAT_EQ(p.blunder_minimum, 10.0f);
+  EXPECT_FLOAT_EQ(p.blunder_percent, 0.25f);
+  EXPECT_FLOAT_EQ(p.blunder_scalar, 3.0f);
+  EXPECT_FLOAT_EQ(p.capture_distance_scale, 0.05f);
+  EXPECT_EQ(p.extractor, CUBE_LHOOD);
+}
+
+}  // namespace cube


### PR DESCRIPTION
## Summary

- Adds gtest-based unit test suite covering all core CUBE algorithm components
- **test_hypothesis** (11 tests): Constructor, null hypothesis, monitor reset, Kalman filter update equations, outlier/intervention detection, Bayes factor drift detection, input sample variance tracking, convergence
- **test_node** (12 tests): Hypothesis add/choose/best, update with outlier intervention, median queue pre-filter, queue flush, depth extraction, outlier truncation, convergence
- **test_parameters** (9 tests): All IHO survey orders (exclusive, special, order1a/b, order2), invalid order exception, distance scale, variance scale, context search range, default parameter values
- **test_grid** (6 tests): Construction, bounds, initial NaN values, single/multiple sounding insertion, out-of-bounds rejection, batch insertion
- **test_map_sheet** (8 tests): Construction, empty state, sounding-triggered grid creation, on-demand grid creation, grid index computation (positive and negative coords), bounds expansion, multi-grid tiling

Also includes a guard against divide-by-zero in `Node::truncate()` for queues with fewer than 3 elements.

> **Merge order**: This PR is rebased on top of PR #20. Merge #20 first, then this PR will apply cleanly.

Closes #17

## Test plan

- [x] All 5 test executables build cleanly
- [x] All 46 unit tests pass (100%)
- [x] Copilot review comments addressed
- [ ] CI passes

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
