### PR TITLE
fix: correct CONF_99PC, uncertainty extraction, and queue flush order

### DIFF
--- a/cube_bathymetry/include/cube_bathymetry/common.h
+++ b/cube_bathymetry/include/cube_bathymetry/common.h
@@ -31,7 +31,7 @@ namespace cube
 {
 
 static constexpr double CONF_95PC = 1.96; /* Scale for 95% CI on Unit Normal */
-static constexpr double CONF_99PC = 2.95; /* Scale for 99% CI on Unit Normal */
+static constexpr double CONF_99PC = 2.576; /* Scale for 99% CI on Unit Normal */
 
 static constexpr float INVALID_DATA = std::numeric_limits<float>::max();
 

--- a/cube_bathymetry/src/node.cpp
+++ b/cube_bathymetry/src/node.cpp
@@ -172,7 +172,7 @@ bool Node::queueEstimate(float depth, float variance, const Parameters & paramet
 DepthAndUncertainty Node::extractDepthAndUncertainty(const Parameters & parameters)
 {
   if(nominated_hypothesis_)
-    return {nominated_hypothesis_->current_estimate, parameters.stddev_to_confidence_interval_scale*std::sqrt(nominated_hypothesis_->current_variance)};
+    return {nominated_hypothesis_->current_estimate, parameters.stddev_to_confidence_interval_scale*std::sqrt(nominated_hypothesis_->input_sample_variance)};
 
   auto h = chooseHypothesis();
 
@@ -181,8 +181,8 @@ DepthAndUncertainty Node::extractDepthAndUncertainty(const Parameters & paramete
     if(h->number_of_samples > 0)
     {
       float depth = h->current_estimate;
-      float variance = parameters.stddev_to_confidence_interval_scale*std::sqrt(h->current_variance);
-      return {depth, variance};
+      float uncertainty = parameters.stddev_to_confidence_interval_scale*std::sqrt(h->input_sample_variance);
+      return {depth, uncertainty};
     }
   }
   
@@ -240,12 +240,28 @@ void Node::queueFlush(const Parameters & parameters)
 
   truncate(parameters);
 
-  while(!queue_.empty())
-  {
-    auto mi = queue_.begin();
-    advance(mi, queue_.size()/2);
-    update(mi->depth, mi->uncertainty, parameters);
-    queue_.erase(mi);
+  // Copy to vector for indexed access (original uses array indices)
+  std::vector<DepthAndUncertainty> q(queue_.begin(), queue_.end());
+  queue_.clear();
+
+  int n = q.size();
+  int ex_pt, direction, scale = 1;
+
+  if ((n % 2) == 0) {
+    // Even: start just left of center, go right first
+    ex_pt = n / 2 - 1;
+    direction = +1;
+  } else {
+    // Odd: start at center, go left first
+    ex_pt = n / 2;
+    direction = -1;
+  }
+
+  while (ex_pt >= 0) {
+    update(q[ex_pt].depth, q[ex_pt].uncertainty, parameters);
+    ex_pt += direction * scale;
+    direction = -direction;
+    scale++;
   }
 
 }


### PR DESCRIPTION
## Summary

- **Fix #10**: Correct `CONF_99PC` constant from `2.95` to `2.576` (correct 99% CI on unit normal, matching original CUBE's `2.56`). The previous value over-estimated confidence bounds, making outlier detection less aggressive and expanding sounding radius of influence.

- **Fix #13**: Use `input_sample_variance` instead of `current_variance` in `extractDepthAndUncertainty()`, matching the original CUBE's default `TRACK_IP_SAMP_VAR` behavior. Posterior variance tends to be smaller, so the previous code reported overly optimistic uncertainty.

- **Fix #14**: Implement the original CUBE's alternating left/right walk from the median in `queueFlush()` instead of repeated middle extraction. The original deliberately processes data starting from the median, alternating between shallower and deeper values, which affects Kalman filter processing order.

Closes #10, Closes #13, Closes #14

## Test plan

- [x] Package builds cleanly
- [ ] CI passes
- [ ] Unit tests in PR #19 should be updated to account for `input_sample_variance` behavior change in `extractDepthAndUncertainty`

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
