### PR TITLE
Add unit tests for error_model and geo_grid

### DIFF
--- a/cube_bathymetry/CMakeLists.txt
+++ b/cube_bathymetry/CMakeLists.txt
@@ -134,6 +134,12 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_geo_map_sheet test/test_geo_map_sheet.cpp)
   target_link_libraries(test_geo_map_sheet cube_bathymetry)
+
+  ament_add_gtest(test_error_model test/test_error_model.cpp)
+  target_link_libraries(test_error_model cube_bathymetry)
+
+  ament_add_gtest(test_geo_grid test/test_geo_grid.cpp)
+  target_link_libraries(test_geo_grid cube_bathymetry)
 endif()
 
 ament_export_dependencies(rclcpp)

--- a/cube_bathymetry/test/test_error_model.cpp
+++ b/cube_bathymetry/test/test_error_model.cpp
@@ -1,0 +1,194 @@
+// Copyright 2025 Center for Coastal and Ocean Mapping and NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+#include "cube_bathymetry/error_model.h"
+#include <cmath>
+#include <vector>
+
+namespace cube
+{
+
+class ErrorModelTest : public ::testing::Test
+{
+protected:
+  Platform makePlatform()
+  {
+    Platform p{};
+    p.timestamp = 0.0;
+    p.latitude = 43.07;
+    p.longitude = -70.76;
+    p.roll = 0.0f;
+    p.pitch = 0.0f;
+    p.heading = 0.0f;
+    p.heave = 0.0f;
+    p.surf_sspeed = 1500.0f;
+    p.mean_speed = 1500.0f;
+    p.vessel_speed = 0.0f;
+    return p;
+  }
+
+  marine_acoustic_msgs::msg::SonarDetections makeDetections(
+    const std::vector<float>& rx_angles,
+    float travel_time,
+    float sound_speed = 1500.0f)
+  {
+    marine_acoustic_msgs::msg::SonarDetections det;
+    det.ping_info.sound_speed = sound_speed;
+    det.ping_info.frequency = 200000.0f;
+
+    for (size_t i = 0; i < rx_angles.size(); ++i) {
+      det.rx_angles.push_back(rx_angles[i]);
+      det.two_way_travel_times.push_back(travel_time);
+    }
+    return det;
+  }
+
+  Vessel vessel{};
+  Device device{};
+};
+
+TEST_F(ErrorModelTest, ConstructorWithDefaults)
+{
+  EXPECT_NO_THROW(ErrorModel(vessel, device));
+}
+
+TEST_F(ErrorModelTest, ComputeNadirBeamReturnsSingleSounding)
+{
+  ErrorModel em(vessel, device);
+  auto platform = makePlatform();
+  auto det = makeDetections({0.0f}, 0.02f);
+
+  auto soundings = em.compute(det, platform);
+  EXPECT_EQ(soundings.size(), 1u);
+}
+
+TEST_F(ErrorModelTest, ComputeReturnsCorrectCount)
+{
+  ErrorModel em(vessel, device);
+  auto platform = makePlatform();
+  auto det = makeDetections({-0.5f, -0.25f, 0.0f, 0.25f, 0.5f}, 0.02f);
+
+  auto soundings = em.compute(det, platform);
+  EXPECT_EQ(soundings.size(), 5u);
+}
+
+TEST_F(ErrorModelTest, DepthIsNegative)
+{
+  ErrorModel em(vessel, device);
+  auto platform = makePlatform();
+  // 0.02s two-way at 1500 m/s → ~15m range, nadir beam → depth ~ -15m
+  auto det = makeDetections({0.0f}, 0.02f);
+
+  auto soundings = em.compute(det, platform);
+  ASSERT_EQ(soundings.size(), 1u);
+  EXPECT_LT(soundings[0].depth, 0.0f);
+}
+
+TEST_F(ErrorModelTest, ErrorsAreNonNegative)
+{
+  ErrorModel em(vessel, device);
+  auto platform = makePlatform();
+  auto det = makeDetections({0.0f, 0.3f, -0.3f}, 0.02f);
+
+  auto soundings = em.compute(det, platform);
+  for (const auto& s : soundings) {
+    EXPECT_GE(s.vertical_error, 0.0f);
+    EXPECT_GE(s.horizontal_error, 0.0f);
+  }
+}
+
+TEST_F(ErrorModelTest, VerticalErrorIncreasesWithBeamAngle)
+{
+  ErrorModel em(vessel, device);
+  auto platform = makePlatform();
+
+  auto det_nadir = makeDetections({0.0f}, 0.02f);
+  auto det_30deg = makeDetections({0.5236f}, 0.02f);  // ~30 degrees
+  auto det_60deg = makeDetections({1.0472f}, 0.02f);  // ~60 degrees
+
+  auto s_nadir = em.compute(det_nadir, platform);
+  auto s_30 = em.compute(det_30deg, platform);
+  auto s_60 = em.compute(det_60deg, platform);
+
+  EXPECT_LT(s_nadir[0].vertical_error, s_30[0].vertical_error);
+  EXPECT_LT(s_30[0].vertical_error, s_60[0].vertical_error);
+}
+
+TEST_F(ErrorModelTest, HorizontalErrorVariesWithBeamAngle)
+{
+  ErrorModel em(vessel, device);
+  auto platform = makePlatform();
+
+  auto det_nadir = makeDetections({0.0f}, 0.02f);
+  auto det_45deg = makeDetections({0.7854f}, 0.02f);  // ~45 degrees
+
+  auto s_nadir = em.compute(det_nadir, platform);
+  auto s_45 = em.compute(det_45deg, platform);
+
+  // Horizontal error changes with beam angle (not constant)
+  EXPECT_NE(s_nadir[0].horizontal_error, s_45[0].horizontal_error);
+}
+
+TEST_F(ErrorModelTest, DepthIncreasesWithTravelTime)
+{
+  ErrorModel em(vessel, device);
+  auto platform = makePlatform();
+
+  auto det_shallow = makeDetections({0.0f}, 0.01f);
+  auto det_deep = makeDetections({0.0f}, 0.04f);
+
+  auto s_shallow = em.compute(det_shallow, platform);
+  auto s_deep = em.compute(det_deep, platform);
+
+  // Depth is negative, so deeper means more negative
+  EXPECT_GT(s_shallow[0].depth, s_deep[0].depth);
+}
+
+TEST_F(ErrorModelTest, SymmetricAnglesProduceSimilarErrors)
+{
+  ErrorModel em(vessel, device);
+  auto platform = makePlatform();
+
+  auto det_port = makeDetections({-0.5f}, 0.02f);
+  auto det_stbd = makeDetections({0.5f}, 0.02f);
+
+  auto s_port = em.compute(det_port, platform);
+  auto s_stbd = em.compute(det_stbd, platform);
+
+  // Errors should be very similar for symmetric angles
+  EXPECT_NEAR(s_port[0].vertical_error, s_stbd[0].vertical_error,
+    s_port[0].vertical_error * 0.01);
+  EXPECT_NEAR(s_port[0].horizontal_error, s_stbd[0].horizontal_error,
+    s_port[0].horizontal_error * 0.01);
+}
+
+TEST_F(ErrorModelTest, EmptyDetectionsReturnsEmpty)
+{
+  ErrorModel em(vessel, device);
+  auto platform = makePlatform();
+  auto det = makeDetections({}, 0.02f);
+
+  auto soundings = em.compute(det, platform);
+  EXPECT_TRUE(soundings.empty());
+}
+
+}  // namespace cube

--- a/cube_bathymetry/test/test_geo_grid.cpp
+++ b/cube_bathymetry/test/test_geo_grid.cpp
@@ -1,0 +1,132 @@
+// Copyright 2025 Center for Coastal and Ocean Mapping and NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+#include "cube_bathymetry/geo_grid.h"
+#include <cmath>
+#include <vector>
+
+namespace cube
+{
+
+class GeoGridTest : public ::testing::Test
+{
+protected:
+  Parameters params{CellSizes(1.0f), "order1a"};
+  gggs::Level level{gggs::Level::fromCellSize(1.0f)};
+
+  gggs::GridIndex makeGridIndex(double lat, double lon)
+  {
+    return level.gridIndex(lat, lon);
+  }
+
+  GeoSounding makeGeoSounding(double lat, double lon, double depth,
+    float vert_err = 0.5f, float horiz_err = 0.1f)
+  {
+    gz4d::GeoPointLatLongDegrees point(lat, lon, depth);
+    GeoSounding s(point);
+    s.sounding.vertical_error = vert_err;
+    s.sounding.horizontal_error = horiz_err;
+    return s;
+  }
+};
+
+TEST_F(GeoGridTest, ConstructorStoresIndex)
+{
+  auto grid_index = makeGridIndex(43.07, -70.76);
+  GeoGrid g(grid_index, params);
+
+  EXPECT_EQ(g.index(), grid_index);
+}
+
+TEST_F(GeoGridTest, InsertSingleSoundingReturnsTrue)
+{
+  auto grid_index = makeGridIndex(43.07, -70.76);
+  GeoGrid g(grid_index, params);
+
+  auto s = makeGeoSounding(43.07, -70.76, -10.0);
+  EXPECT_TRUE(g.insert(s));
+}
+
+TEST_F(GeoGridTest, InsertEmptyVectorReturnsFalse)
+{
+  auto grid_index = makeGridIndex(43.07, -70.76);
+  GeoGrid g(grid_index, params);
+
+  std::vector<GeoSounding> empty;
+  EXPECT_FALSE(g.insert(empty));
+}
+
+TEST_F(GeoGridTest, InsertNonEmptyVectorReturnsTrue)
+{
+  auto grid_index = makeGridIndex(43.07, -70.76);
+  GeoGrid g(grid_index, params);
+
+  std::vector<GeoSounding> soundings;
+  soundings.push_back(makeGeoSounding(43.07, -70.76, -10.0));
+  soundings.push_back(makeGeoSounding(43.07, -70.76, -10.5));
+  EXPECT_TRUE(g.insert(soundings));
+}
+
+TEST_F(GeoGridTest, ValuesAfterInsertionsContainsValidDepths)
+{
+  auto grid_index = makeGridIndex(43.07, -70.76);
+  GeoGrid g(grid_index, params);
+
+  // Insert enough soundings to trigger hypothesis creation
+  for (int i = 0; i < 20; ++i) {
+    g.insert(makeGeoSounding(43.07, -70.76, -10.0));
+  }
+
+  auto vals = g.values();
+  bool found_valid = false;
+  for (const auto& v : vals) {
+    if (!std::isnan(v.depth)) {
+      found_valid = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found_valid);
+}
+
+TEST_F(GeoGridTest, MultipleSoundingsConverge)
+{
+  auto grid_index = makeGridIndex(43.07, -70.76);
+  GeoGrid g(grid_index, params);
+
+  // Insert many consistent soundings at the same location
+  for (int i = 0; i < 30; ++i) {
+    g.insert(makeGeoSounding(43.07, -70.76, -10.0));
+  }
+
+  auto vals = g.values();
+  bool found_close = false;
+  for (const auto& v : vals) {
+    if (!std::isnan(v.depth)) {
+      // Depth should converge toward the inserted value
+      EXPECT_NEAR(v.depth, -10.0f, 2.0f);
+      found_close = true;
+    }
+  }
+  EXPECT_TRUE(found_close);
+}
+
+}  // namespace cube


### PR DESCRIPTION
## Summary

Adds unit tests for the two remaining untested core CUBE algorithm modules:

- **`test_error_model`** (10 tests): Behavioral tests for `ErrorModel::compute()` covering depth sign conventions, error non-negativity, vertical error monotonicity with beam angle, horizontal error variation, depth scaling with travel time, symmetric beam behavior, and empty input handling.
- **`test_geo_grid`** (6 tests): Tests for `GeoGrid` construction, single/vector sounding insertion, empty vector rejection, value retrieval after insertions, and depth convergence with repeated soundings.

Contributes to #4 — all core modules now have test coverage.

## Test plan

- [x] `test_error_model` — 10/10 tests pass
- [x] `test_geo_grid` — 6/6 tests pass
- [x] All existing tests (`test_hypothesis`, `test_node`, `test_parameters`, `test_grid`, `test_map_sheet`, `test_geo_map_sheet`) still pass
- [x] No build regressions

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
