### PR TITLE
[PLAN] Build failure: cellColumnCount() API change in marine_autonomy

### DIFF
--- a/.agent/work-plans/PLAN_ISSUE-26.md
+++ b/.agent/work-plans/PLAN_ISSUE-26.md
@@ -1,0 +1,91 @@
+# Plan: Build failure — cellColumnCount() API change in marine_autonomy
+
+## Issue
+
+https://github.com/rolker/cube_bathymetry/issues/26
+
+## Context
+
+The upstream `marine_autonomy` package changed `gggs::GridBounds::cellColumnCount()`
+to require a `uint32_t row` parameter, reflecting that GGGS uses polar scaling
+(1×/3×/9× longitude widening at 72°/80° latitude thresholds). The previous no-arg
+signature assumed uniform column counts across all rows.
+
+`bag_to_geotiff.cpp` calls `bounds.cellColumnCount()` at line 432 to determine the
+total GeoTIFF raster width. This is the only broken call site — the other 6 calls
+use `grid->index().cellColumnCount()` on `GridIndex`, which is a `static constexpr`
+(always 960) and is unaffected.
+
+However, fixing line 432 requires more than adding a row parameter. A GeoTIFF has
+uniform pixel dimensions, but `GridBounds` may span rows with different column
+counts. Per maintainer direction: use the widest row for raster width, and
+interpolate narrower (polar-scaled) rows to fill the full width.
+
+## Approach
+
+1. **Compute max column count across all rows** — Iterate from
+   `bounds.minimum().row()` to `bounds.maximum().row()`, calling
+   `bounds.cellColumnCount(row)` for each grid row, and track the maximum.
+   Use this as the GeoTIFF raster width (`columns`).
+
+2. **Adjust the per-grid write loop for variable column widths** — Currently
+   lines 466–483 compute `column_offset` and write each grid's 960×960 block
+   assuming uniform column spacing. When a grid is in a polar-scaled row
+   (fewer grid columns = fewer cell columns in the bounds), its data must be
+   stretched to fill the wider raster. The stretch factor is the ratio of
+   the max column count to the current row's column count (always 1, 3, or 9).
+
+   For rows that need stretching:
+   - Use nearest-neighbor resampling: each source cell maps to
+     `stretch_factor` output pixels.
+   - Expand values into a temporary row buffer before writing to GDAL.
+   - Apply the same stretching to both depth and uncertainty bands.
+
+3. **Adjust column_offset for polar rows** — The `column_offset` calculation
+   on line 468 uses `grid->index().cellColumnCount()` (always 960). This is
+   correct for the source data indexing, but the *output* column offset must
+   be scaled by the stretch factor so polar grids are placed correctly in
+   the wider raster.
+
+4. **Build and verify** — Confirm `bag_to_geotiff` compiles and links
+   successfully. Since there are no automated tests for this tool, verify
+   the build is the primary check.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `cube_bathymetry/src/bag_to_geotiff.cpp` | Fix `cellColumnCount()` call; add max-column computation; add row stretching logic for polar-scaled rows |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| A change includes its consequences | The only downstream consumer of this code is the GeoTIFF file itself. No documentation references specific output dimensions. Build verification is sufficient. |
+| Only what's needed | Minimal change: fix the compilation error and handle variable-width rows. No refactoring beyond what's needed. |
+| Test what breaks | No existing tests for `bag_to_geotiff`. Adding tests is tracked separately (#3, #4). Build verification confirms the fix compiles. |
+| Improve incrementally | Single focused fix in one file. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0002 — Worktree isolation | Yes | Working in `feature/issue-26` worktree |
+| 0008 — ROS 2 conventions | No | No package structure changes |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| GeoTIFF output geometry | Any documentation describing output format | Yes — no such docs exist currently |
+| `bag_to_geotiff.cpp` compilation | `make build` should succeed end-to-end | Yes — build verification in step 4 |
+
+## Open Questions
+
+- **Interpolation method**: Nearest-neighbor is simplest and preserves exact
+  depth/uncertainty values. Bilinear would smooth across cell boundaries.
+  Plan uses nearest-neighbor; maintainer can request bilinear if preferred.
+
+## Estimated Scope
+
+Single PR, single file change.

--- a/.agent/work-plans/PLAN_ISSUE-26.md
+++ b/.agent/work-plans/PLAN_ISSUE-26.md
@@ -36,10 +36,11 @@ interpolate narrower (polar-scaled) rows to fill the full width.
    the max column count to the current row's column count (always 1, 3, or 9).
 
    For rows that need stretching:
-   - Use nearest-neighbor resampling: each source cell maps to
-     `stretch_factor` output pixels.
+   - Use bilinear interpolation: blend adjacent source cells to produce
+     smooth output pixels across the stretch factor boundary.
    - Expand values into a temporary row buffer before writing to GDAL.
    - Apply the same stretching to both depth and uncertainty bands.
+   - Treat NaN source cells as missing — do not blend NaN into neighbors.
 
 3. **Adjust column_offset for polar rows** — The `column_offset` calculation
    on line 468 uses `grid->index().cellColumnCount()` (always 960). This is
@@ -82,9 +83,7 @@ interpolate narrower (polar-scaled) rows to fill the full width.
 
 ## Open Questions
 
-- **Interpolation method**: Nearest-neighbor is simplest and preserves exact
-  depth/uncertainty values. Bilinear would smooth across cell boundaries.
-  Plan uses nearest-neighbor; maintainer can request bilinear if preferred.
+None — interpolation method (bilinear) confirmed by maintainer.
 
 ## Estimated Scope
 

--- a/cube_bathymetry/src/bag_to_geotiff.cpp
+++ b/cube_bathymetry/src/bag_to_geotiff.cpp
@@ -20,6 +20,7 @@
 // THE SOFTWARE.
 
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <vector>
@@ -490,6 +491,15 @@ int main(int argc, char *argv[])
 
     // gdal organizes data with first row being top row
     auto gdal_y_index = rows - row_offset - grid->index().cellRowCount();
+
+    // Allocate interpolation buffers once per grid (reused across rows)
+    std::vector<float> depth_buf;
+    std::vector<float> uncert_buf;
+    if(stretch_factor != 1) {
+      depth_buf.resize(out_cols);
+      uncert_buf.resize(out_cols);
+    }
+
     for(int row = 0; row < grid->index().cellRowCount(); row++) {
       auto gdal_row = gdal_y_index + grid->index().cellRowCount() - 1 - row;
       auto src_row_offset = row * src_cols;
@@ -506,8 +516,6 @@ int main(int argc, char *argv[])
           GDT_Float32, 2 * sizeof(float), 0);
       } else {
         // Polar-scaled row: interpolate to fill the wider raster
-        std::vector<float> depth_buf(out_cols);
-        std::vector<float> uncert_buf(out_cols);
 
         for(uint32_t p = 0; p < out_cols; p++) {
           // Map output pixel center to source cell position

--- a/cube_bathymetry/src/bag_to_geotiff.cpp
+++ b/cube_bathymetry/src/bag_to_geotiff.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <limits>
 #include <vector>
 
 #include "tf2_ros/buffer.h"
@@ -492,12 +493,28 @@ int main(int argc, char *argv[])
     // gdal organizes data with first row being top row
     auto gdal_y_index = rows - row_offset - grid->index().cellRowCount();
 
-    // Allocate interpolation buffers once per grid (reused across rows)
+    // Precompute interpolation lookup table and buffers once per grid
+    struct InterpEntry
+    {
+      int left;
+      int right;
+      float t;
+    };
+    std::vector<InterpEntry> interp_table;
     std::vector<float> depth_buf;
     std::vector<float> uncert_buf;
     if(stretch_factor != 1) {
       depth_buf.resize(out_cols);
       uncert_buf.resize(out_cols);
+      interp_table.resize(out_cols);
+      for(uint32_t p = 0; p < out_cols; p++) {
+        double src_pos = (p + 0.5) / stretch_factor - 0.5;
+        int left = static_cast<int>(std::floor(src_pos));
+        int right = left + 1;
+        interp_table[p].t = static_cast<float>(src_pos - left);
+        interp_table[p].left = std::clamp(left, 0, static_cast<int>(src_cols) - 1);
+        interp_table[p].right = std::clamp(right, 0, static_cast<int>(src_cols) - 1);
+      }
     }
 
     for(int row = 0; row < grid->index().cellRowCount(); row++) {
@@ -518,19 +535,12 @@ int main(int argc, char *argv[])
         // Polar-scaled row: interpolate to fill the wider raster
 
         for(uint32_t p = 0; p < out_cols; p++) {
-          // Map output pixel center to source cell position
-          double src_pos = (p + 0.5) / stretch_factor - 0.5;
-          int left = static_cast<int>(std::floor(src_pos));
-          int right = left + 1;
-          double t = src_pos - left;
+          const auto & ie = interp_table[p];
 
-          left = std::clamp(left, 0, static_cast<int>(src_cols) - 1);
-          right = std::clamp(right, 0, static_cast<int>(src_cols) - 1);
-
-          float d_left = values[src_row_offset + left].depth;
-          float d_right = values[src_row_offset + right].depth;
-          float u_left = values[src_row_offset + left].uncertainty;
-          float u_right = values[src_row_offset + right].uncertainty;
+          float d_left = values[src_row_offset + ie.left].depth;
+          float d_right = values[src_row_offset + ie.right].depth;
+          float u_left = values[src_row_offset + ie.left].uncertainty;
+          float u_right = values[src_row_offset + ie.right].uncertainty;
 
           // NaN-aware linear interpolation
           bool d_left_nan = std::isnan(d_left);
@@ -542,7 +552,7 @@ int main(int argc, char *argv[])
           } else if(d_right_nan) {
             depth_buf[p] = d_left;
           } else {
-            depth_buf[p] = static_cast<float>((1.0 - t) * d_left + t * d_right);
+            depth_buf[p] = (1.0f - ie.t) * d_left + ie.t * d_right;
           }
 
           bool u_left_nan = std::isnan(u_left);
@@ -554,7 +564,7 @@ int main(int argc, char *argv[])
           } else if(u_right_nan) {
             uncert_buf[p] = u_left;
           } else {
-            uncert_buf[p] = static_cast<float>((1.0 - t) * u_left + t * u_right);
+            uncert_buf[p] = (1.0f - ie.t) * u_left + ie.t * u_right;
           }
         }
 

--- a/cube_bathymetry/src/bag_to_geotiff.cpp
+++ b/cube_bathymetry/src/bag_to_geotiff.cpp
@@ -21,6 +21,8 @@
 
 
 #include <chrono>
+#include <cmath>
+#include <vector>
 
 #include "tf2_ros/buffer.h"
 #include "tf2_msgs/msg/tf_message.hpp"
@@ -429,7 +431,13 @@ int main(int argc, char *argv[])
   std::cout << "grid bounds: " << bounds << std::endl;
 
   auto rows = bounds.cellRowCount();
-  auto columns = bounds.cellColumnCount();
+
+  // Compute max column count across all grid rows to determine raster width.
+  // Column count varies by latitude due to GGGS polar scaling (1x/3x/9x).
+  uint64_t columns = 0;
+  for(uint32_t r = bounds.minimum().row(); r <= bounds.maximum().row(); r++) {
+    columns = std::max(columns, bounds.cellColumnCount(r));
+  }
   std::cout << "Total cells: " << rows << " rows by " << columns << " columns" << std::endl;
 
   GDALAllRegister();
@@ -442,7 +450,8 @@ int main(int argc, char *argv[])
 
   auto cellsize = geo_map_sheet.cellSizeDegrees();
 
-  double geo_transform[6] = {bounds.minimum().westLongitude(), cellsize, 0,
+  double raster_west = bounds.minimum().westLongitude();
+  double geo_transform[6] = {raster_west, cellsize, 0,
     bounds.maximum().northLatitude(), 0, -cellsize};
   dataset->SetGeoTransform(geo_transform);
 
@@ -464,21 +473,92 @@ int main(int argc, char *argv[])
 
   auto grids = geo_map_sheet.grids();
   for (auto grid  :  grids) {
-    auto row_offset = (grid->index().row() - bounds.minimum().row()) * grid->index().cellRowCount();
-    auto column_offset = (grid->index().column() - bounds.minimum().column()) *
-      grid->index().cellColumnCount();
+    auto grid_row = grid->index().row();
+    auto row_offset = (grid_row - bounds.minimum().row()) * grid->index().cellRowCount();
+
+    // Compute output column offset from longitude difference
+    auto column_offset = static_cast<int64_t>(
+      std::round((grid->index().westLongitude() - raster_west) / cellsize));
+
+    // Stretch factor: ratio of max columns to this row's columns (1, 3, or 9)
+    auto row_columns = bounds.cellColumnCount(grid_row);
+    uint32_t stretch_factor = (row_columns > 0) ? columns / row_columns : 1;
+
     auto values = grid->values();
+    auto src_cols = grid->index().cellColumnCount();  // always 960
+    auto out_cols = static_cast<uint32_t>(src_cols) * stretch_factor;
+
     // gdal organizes data with first row being top row
     auto gdal_y_index = rows - row_offset - grid->index().cellRowCount();
     for(int row = 0; row < grid->index().cellRowCount(); row++) {
-      dataset->GetRasterBand(1)->RasterIO(GF_Write, column_offset,
-        gdal_y_index + grid->index().cellRowCount() - 1 - row, grid->index().cellColumnCount(), 1,
-        &(values[row * grid->index().cellColumnCount()].depth), grid->index().cellColumnCount(), 1,
-        GDT_Float32, 2 * sizeof(float), 0);
-      dataset->GetRasterBand(2)->RasterIO(GF_Write, column_offset,
-        gdal_y_index + grid->index().cellRowCount() - 1 - row, grid->index().cellColumnCount(), 1,
-        &(values[row * grid->index().cellColumnCount()].uncertainty),
-        grid->index().cellColumnCount(), 1, GDT_Float32, 2 * sizeof(float), 0);
+      auto gdal_row = gdal_y_index + grid->index().cellRowCount() - 1 - row;
+      auto src_row_offset = row * src_cols;
+
+      if(stretch_factor == 1) {
+        // No stretching needed — write source data directly
+        dataset->GetRasterBand(1)->RasterIO(GF_Write, column_offset,
+          gdal_row, src_cols, 1,
+          &(values[src_row_offset].depth), src_cols, 1,
+          GDT_Float32, 2 * sizeof(float), 0);
+        dataset->GetRasterBand(2)->RasterIO(GF_Write, column_offset,
+          gdal_row, src_cols, 1,
+          &(values[src_row_offset].uncertainty), src_cols, 1,
+          GDT_Float32, 2 * sizeof(float), 0);
+      } else {
+        // Polar-scaled row: interpolate to fill the wider raster
+        std::vector<float> depth_buf(out_cols);
+        std::vector<float> uncert_buf(out_cols);
+
+        for(uint32_t p = 0; p < out_cols; p++) {
+          // Map output pixel center to source cell position
+          double src_pos = (p + 0.5) / stretch_factor - 0.5;
+          int left = static_cast<int>(std::floor(src_pos));
+          int right = left + 1;
+          double t = src_pos - left;
+
+          left = std::clamp(left, 0, static_cast<int>(src_cols) - 1);
+          right = std::clamp(right, 0, static_cast<int>(src_cols) - 1);
+
+          float d_left = values[src_row_offset + left].depth;
+          float d_right = values[src_row_offset + right].depth;
+          float u_left = values[src_row_offset + left].uncertainty;
+          float u_right = values[src_row_offset + right].uncertainty;
+
+          // NaN-aware linear interpolation
+          bool d_left_nan = std::isnan(d_left);
+          bool d_right_nan = std::isnan(d_right);
+          if(d_left_nan && d_right_nan) {
+            depth_buf[p] = nan;
+          } else if(d_left_nan) {
+            depth_buf[p] = d_right;
+          } else if(d_right_nan) {
+            depth_buf[p] = d_left;
+          } else {
+            depth_buf[p] = static_cast<float>((1.0 - t) * d_left + t * d_right);
+          }
+
+          bool u_left_nan = std::isnan(u_left);
+          bool u_right_nan = std::isnan(u_right);
+          if(u_left_nan && u_right_nan) {
+            uncert_buf[p] = nan;
+          } else if(u_left_nan) {
+            uncert_buf[p] = u_right;
+          } else if(u_right_nan) {
+            uncert_buf[p] = u_left;
+          } else {
+            uncert_buf[p] = static_cast<float>((1.0 - t) * u_left + t * u_right);
+          }
+        }
+
+        dataset->GetRasterBand(1)->RasterIO(GF_Write, column_offset,
+          gdal_row, out_cols, 1,
+          depth_buf.data(), out_cols, 1,
+          GDT_Float32, 0, 0);
+        dataset->GetRasterBand(2)->RasterIO(GF_Write, column_offset,
+          gdal_row, out_cols, 1,
+          uncert_buf.data(), out_cols, 1,
+          GDT_Float32, 0, 0);
+      }
     }
   }
 


### PR DESCRIPTION
Closes #26

# Plan: Build failure — cellColumnCount() API change in marine_autonomy

## Issue

https://github.com/rolker/cube_bathymetry/issues/26

## Context

The upstream `marine_autonomy` package changed `gggs::GridBounds::cellColumnCount()`
to require a `uint32_t row` parameter, reflecting that GGGS uses polar scaling
(1×/3×/9× longitude widening at 72°/80° latitude thresholds). The previous no-arg
signature assumed uniform column counts across all rows.

`bag_to_geotiff.cpp` calls `bounds.cellColumnCount()` at line 432 to determine the
total GeoTIFF raster width. This is the only broken call site — the other 6 calls
use `grid->index().cellColumnCount()` on `GridIndex`, which is a `static constexpr`
(always 960) and is unaffected.

However, fixing line 432 requires more than adding a row parameter. A GeoTIFF has
uniform pixel dimensions, but `GridBounds` may span rows with different column
counts. Per maintainer direction: use the widest row for raster width, and
interpolate narrower (polar-scaled) rows to fill the full width.

## Approach

1. **Compute max column count across all rows** — Iterate from
   `bounds.minimum().row()` to `bounds.maximum().row()`, calling
   `bounds.cellColumnCount(row)` for each grid row, and track the maximum.
   Use this as the GeoTIFF raster width (`columns`).

2. **Adjust the per-grid write loop for variable column widths** — Currently
   lines 466–483 compute `column_offset` and write each grid's 960×960 block
   assuming uniform column spacing. When a grid is in a polar-scaled row
   (fewer grid columns = fewer cell columns in the bounds), its data must be
   stretched to fill the wider raster. The stretch factor is the ratio of
   the max column count to the current row's column count (always 1, 3, or 9).

   For rows that need stretching:
   - Use nearest-neighbor resampling: each source cell maps to
     `stretch_factor` output pixels.
   - Expand values into a temporary row buffer before writing to GDAL.
   - Apply the same stretching to both depth and uncertainty bands.

3. **Adjust column_offset for polar rows** — The `column_offset` calculation
   on line 468 uses `grid->index().cellColumnCount()` (always 960). This is
   correct for the source data indexing, but the *output* column offset must
   be scaled by the stretch factor so polar grids are placed correctly in
   the wider raster.

4. **Build and verify** — Confirm `bag_to_geotiff` compiles and links
   successfully. Since there are no automated tests for this tool, verify
   the build is the primary check.

## Files to Change

| File | Change |
|------|--------|
| `cube_bathymetry/src/bag_to_geotiff.cpp` | Fix `cellColumnCount()` call; add max-column computation; add row stretching logic for polar-scaled rows |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| A change includes its consequences | The only downstream consumer of this code is the GeoTIFF file itself. No documentation references specific output dimensions. Build verification is sufficient. |
| Only what's needed | Minimal change: fix the compilation error and handle variable-width rows. No refactoring beyond what's needed. |
| Test what breaks | No existing tests for `bag_to_geotiff`. Adding tests is tracked separately (#3, #4). Build verification confirms the fix compiles. |
| Improve incrementally | Single focused fix in one file. |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| 0002 — Worktree isolation | Yes | Working in `feature/issue-26` worktree |
| 0008 — ROS 2 conventions | No | No package structure changes |

## Consequences

| If we change... | Also update... | Included in plan? |
|---|---|---|
| GeoTIFF output geometry | Any documentation describing output format | Yes — no such docs exist currently |
| `bag_to_geotiff.cpp` compilation | `make build` should succeed end-to-end | Yes — build verification in step 4 |

## Open Questions

- **Interpolation method**: Nearest-neighbor is simplest and preserves exact
  depth/uncertainty values. Bilinear would smooth across cell boundaries.
  Plan uses nearest-neighbor; maintainer can request bilinear if preferred.

## Estimated Scope

Single PR, single file change.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
