### PR TITLE
Adapt detections_to_pointcloud to TwistWithCovarianceStamped

### DIFF
--- a/cube_bathymetry/src/detections_to_pointcloud.cpp
+++ b/cube_bathymetry/src/detections_to_pointcloud.cpp
@@ -129,7 +129,10 @@ private:
     }
     auto velocity = navigation_sensors_->latest_velocity();
     if(notTooOld(velocity.header.stamp, msg->header.stamp)) {
-      platform.vessel_speed = velocity.twist.linear.x;
+      // mru_transform's VelocitySensor::ValueType is TwistWithCovarianceStamped,
+      // so velocity.twist is a TwistWithCovariance wrapping the inner Twist
+      // at .twist.twist.  See rolker/mru_transform#18 / PR #19.
+      platform.vessel_speed = velocity.twist.twist.linear.x;
     } else {
       RCLCPP_WARN_STREAM_THROTTLE(get_logger(), *get_clock(), 10000,
         "No recent velocity data, setting speed to NaN");


### PR DESCRIPTION
Closes #28

## Summary

`mru_transform` PR [rolker/mru_transform#19](https://github.com/rolker/mru_transform/pull/19)
(REP-105 twist rotation + covariance preservation) changed
`VelocitySensor::ValueType` from `geometry_msgs::msg::TwistStamped` to
`geometry_msgs::msg::TwistWithCovarianceStamped`, so
`NavigationSensors::latest_velocity()` now returns the
covariance-bearing type.

`cube_bathymetry/src/detections_to_pointcloud.cpp` consumed
`latest_velocity().twist.linear.x` — with the new type, `.twist` is a
`TwistWithCovariance` and the inner `Twist` is at `.twist.twist`.

## Change

Single line + explanatory comment:

```diff
-      platform.vessel_speed = velocity.twist.linear.x;
+      // mru_transform's VelocitySensor::ValueType is TwistWithCovarianceStamped,
+      // so velocity.twist is a TwistWithCovariance wrapping the inner Twist
+      // at .twist.twist.  See rolker/mru_transform#18 / PR #19.
+      platform.vessel_speed = velocity.twist.twist.linear.x;
```

Same semantics — body-forward velocity into the cube error model as
vessel speed.

## Build

`colcon build --packages-select cube_bathymetry` succeeds cleanly in
the worktree.  `make build` from the workspace root will succeed once
this merges (`sensors` layer currently blocked only on this one file).

## Test plan

- [x] Workspace-level `make build` succeeds across all layers
  (validated in worktree)
- [ ] No behavioral change expected — semantics identical; covers the
  same body-forward velocity component

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
