### PR TITLE
Single pose source for the cube data flow: slim Platform + source pose from TF/odom

### DIFF
--- a/cube_bathymetry/CMakeLists.txt
+++ b/cube_bathymetry/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(grid_map_ros REQUIRED)
 find_package(lifecycle_msgs)
 find_package(marine_acoustic_msgs REQUIRED)
-find_package(mru_transform REQUIRED)  # For navigation_sensors
+find_package(nav_msgs REQUIRED)  # odometry for speed-over-ground
 find_package(marine_autonomy REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
@@ -80,10 +80,11 @@ target_link_libraries(detections_to_pointcloud
   cube_bathymetry
   ${geometry_msgs_TARGETS}
   ${marine_acoustic_msgs_TARGETS}
-  mru_transform::mru_transform
+  ${nav_msgs_TARGETS}
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle
   ${sensor_msgs_TARGETS}
+  tf2_ros::tf2_ros
 )
 
 install(TARGETS detections_to_pointcloud

--- a/cube_bathymetry/include/cube_bathymetry/error_model.h
+++ b/cube_bathymetry/include/cube_bathymetry/error_model.h
@@ -44,11 +44,11 @@ namespace cube
   struct Platform
   {
     double timestamp;  /* seconds (with ms accuracy) since 00:00 01/01/1970 */
-    double latitude;  /* Latitude in degrees */
-    double longitude;  /* Longitude in degrees */
+    /* No latitude/longitude/heading: the error model never uses them. They were
+     * inherited from Calder's Platform (where they fed georeferencing); in this
+     * ROS port georeferencing is done by TF, so they were dead fields. */
     float roll;  /* Roll in degrees, +ve is port side up */
     float pitch;  /* Pitch in degrees, +ve is bow up */
-    float heading;  /* Heading in degrees, +ve CW from N */
     float heave;  /* Heave in meters, +ve down */
     float surf_sspeed;  /* Surface sound speed, m/s */
     float mean_speed;  /* Geometric mean equivalent sound speed, m/s */

--- a/cube_bathymetry/package.xml
+++ b/cube_bathymetry/package.xml
@@ -14,7 +14,7 @@
   <build_depend>libgdal-dev</build_depend>
   <depend>lifecycle_msgs</depend>
   <depend>marine_acoustic_msgs</depend>
-  <depend>mru_transform</depend>  <!-- For navigation_sensors -->
+  <depend>nav_msgs</depend>  <!-- odometry for speed-over-ground -->
   <depend>marine_autonomy</depend>
   <depend>rclcpp</depend>
   <depend>rosbag2_transport</depend>

--- a/cube_bathymetry/src/detections_to_pointcloud.cpp
+++ b/cube_bathymetry/src/detections_to_pointcloud.cpp
@@ -103,29 +103,20 @@ private:
     cube::Platform platform;
     platform.timestamp = rclcpp::Time(msg->header.stamp).seconds();
 
-    auto position = navigation_sensors_->latest_position();
-    if(notTooOld(position.header.stamp, msg->header.stamp)) {
-      platform.latitude = position.position.latitude;
-      platform.longitude = position.position.longitude;
-    } else {
-      RCLCPP_WARN_STREAM_THROTTLE(get_logger(), *get_clock(), 10000,
-        "No recent position data, setting lat/lon to NaN");
-      platform.latitude = std::nan("");
-      platform.longitude = std::nan("");
-    }
+    // Position (lat/lon) is not needed: the error model never uses it, and the
+    // sounding placement is done downstream by TF.
     auto orientation = navigation_sensors_->latest_orientation();
     if(notTooOld(orientation.header.stamp, msg->header.stamp)) {
       double y, p, r;
       tf2::getEulerYPR(orientation.orientation, y, p, r);
       platform.roll = r;
       platform.pitch = p;
-      platform.heading = (M_PI / 2.0) - y;
+      (void)y;  // yaw/heading unused by the error model (#31; #32)
     } else {
       RCLCPP_WARN_STREAM_THROTTLE(get_logger(), *get_clock(), 10000,
-        "No recent orientation data, setting roll/pitch/heading to NaN");
+        "No recent orientation data, setting roll/pitch to NaN");
       platform.roll = std::nan("");
       platform.pitch = std::nan("");
-      platform.heading = std::nan("");
     }
     auto velocity = navigation_sensors_->latest_velocity();
     if(notTooOld(velocity.header.stamp, msg->header.stamp)) {

--- a/cube_bathymetry/src/detections_to_pointcloud.cpp
+++ b/cube_bathymetry/src/detections_to_pointcloud.cpp
@@ -20,18 +20,21 @@
 // THE SOFTWARE.
 
 
+#include <cmath>
+#include <mutex>
+#include <string>
+
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 
 #include "cube_bathymetry/error_model.h"
-#include "geometry_msgs/msg/twist_with_covariance_stamped.hpp"
 #include "marine_acoustic_msgs/msg/sonar_detections.hpp"
-#include "mru_transform/navigation_sensors.hpp"
-#include "sensor_msgs/msg/imu.hpp"
-#include "sensor_msgs/msg/nav_sat_fix.hpp"
+#include "nav_msgs/msg/odometry.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "tf2_ros/buffer.h"
+#include "tf2_ros/transform_listener.h"
 #include "tf2/utils.hpp"
 
 class DetectionsToPointCloud : public rclcpp_lifecycle::LifecycleNode
@@ -57,13 +60,35 @@ public:
     maximum_range_ = get_parameter("maximum_range").as_double();
     maximum_range_sq_ = maximum_range_ * maximum_range_;
 
+    // TF frame names (platform-specific; set via params/yaml). Defaults are the
+    // unprefixed mru_transform names; e.g. on BizzyBoat set to bizzy/base_link etc.
+    if(!has_parameter("base_link_frame")) {
+      declare_parameter("base_link_frame", base_link_frame_);
+    }
+    base_link_frame_ = get_parameter("base_link_frame").as_string();
+    if(!has_parameter("level_frame")) {
+      declare_parameter("level_frame", level_frame_);
+    }
+    level_frame_ = get_parameter("level_frame").as_string();
+    if(!has_parameter("tide_frame")) {
+      declare_parameter("tide_frame", tide_frame_);
+    }
+    tide_frame_ = get_parameter("tide_frame").as_string();
+
     detections_subscriber_ = create_subscription<marine_acoustic_msgs::msg::SonarDetections>(
       "detections",
       rclcpp::SensorDataQoS(),
       std::bind(&DetectionsToPointCloud::detectionsCallback, this, std::placeholders::_1)
     );
 
-    navigation_sensors_ = std::make_shared<mru_transform::NavigationSensors>(*this);
+    tf_buffer_ = std::make_shared<tf2_ros::Buffer>(get_clock());
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+
+    odom_subscriber_ = create_subscription<nav_msgs::msg::Odometry>(
+      "odom",
+      rclcpp::SensorDataQoS(),
+      std::bind(&DetectionsToPointCloud::odomCallback, this, std::placeholders::_1)
+    );
 
     pointcloud_publisher_ = create_publisher<sensor_msgs::msg::PointCloud2>(
       "soundings",
@@ -98,36 +123,59 @@ private:
     return (current_time - msg_time).seconds() < 1.0;
   }
 
+  void odomCallback(const nav_msgs::msg::Odometry::SharedPtr msg)
+  {
+    const auto & v = msg->twist.twist.linear;  // body-frame velocity
+    std::lock_guard<std::mutex> lock(odom_mutex_);
+    last_vessel_speed_ = static_cast<float>(std::hypot(v.x, v.y));  // SOG
+    last_odom_stamp_ = msg->header.stamp;
+  }
+
   void detectionsCallback(const marine_acoustic_msgs::msg::SonarDetections::UniquePtr & msg)
   {
     cube::Platform platform;
     platform.timestamp = rclcpp::Time(msg->header.stamp).seconds();
 
-    // Position (lat/lon) is not needed: the error model never uses it, and the
-    // sounding placement is done downstream by TF.
-    auto orientation = navigation_sensors_->latest_orientation();
-    if(notTooOld(orientation.header.stamp, msg->header.stamp)) {
+    const rclcpp::Time stamp(msg->header.stamp);
+
+    // Attitude (roll/pitch) from TF at the ping stamp -- the SAME pose used
+    // downstream to place the soundings, so the error budget is coherent, and
+    // it is interpolated to the exact stamp rather than "latest received".
+    // Position and heading are not needed by the error model.
+    try {
+      const auto level = tf_buffer_->lookupTransform(level_frame_, base_link_frame_, stamp);
       double y, p, r;
-      tf2::getEulerYPR(orientation.orientation, y, p, r);
+      tf2::getEulerYPR(level.transform.rotation, y, p, r);
       platform.roll = r;
       platform.pitch = p;
-      (void)y;  // yaw/heading unused by the error model (#31; #32)
-    } else {
+      (void)y;  // yaw/heading unused by the error model
+    } catch (const tf2::TransformException & e) {
       RCLCPP_WARN_STREAM_THROTTLE(get_logger(), *get_clock(), 10000,
-        "No recent orientation data, setting roll/pitch to NaN");
+        "No attitude TF (" << level_frame_ << " <- " << base_link_frame_ <<
+        ") at ping time; roll/pitch = NaN: " << e.what());
       platform.roll = std::nan("");
       platform.pitch = std::nan("");
     }
-    auto velocity = navigation_sensors_->latest_velocity();
-    if(notTooOld(velocity.header.stamp, msg->header.stamp)) {
-      // mru_transform's VelocitySensor::ValueType is TwistWithCovarianceStamped,
-      // so velocity.twist is a TwistWithCovariance wrapping the inner Twist
-      // at .twist.twist.  See rolker/mru_transform#18 / PR #19.
-      platform.vessel_speed = velocity.twist.twist.linear.x;
-    } else {
-      RCLCPP_WARN_STREAM_THROTTLE(get_logger(), *get_clock(), 10000,
-        "No recent velocity data, setting speed to NaN");
-      platform.vessel_speed = std::nan("");
+
+    // Heave = boat vertical offset from the tide-corrected surface. It enters
+    // the budget only squared, so it is non-critical; default to 0 if absent.
+    try {
+      platform.heave = static_cast<float>(tf_buffer_->lookupTransform(
+        tide_frame_, base_link_frame_, stamp).transform.translation.z);
+    } catch (const tf2::TransformException &) {
+      platform.heave = 0.0f;
+    }
+
+    // Speed over ground from odometry (latest cached value).
+    {
+      std::lock_guard<std::mutex> lock(odom_mutex_);
+      if(notTooOld(last_odom_stamp_, stamp)) {
+        platform.vessel_speed = last_vessel_speed_;
+      } else {
+        RCLCPP_WARN_STREAM_THROTTLE(get_logger(), *get_clock(), 10000,
+          "No recent odometry; vessel_speed = NaN");
+        platform.vessel_speed = std::nan("");
+      }
     }
 
     platform.mean_speed = msg->ping_info.sound_speed;
@@ -204,12 +252,22 @@ private:
   rclcpp::Subscription<marine_acoustic_msgs::msg::SonarDetections>::SharedPtr
     detections_subscriber_;
 
-  std::shared_ptr<mru_transform::NavigationSensors> navigation_sensors_;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_subscriber_;
 
   rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::PointCloud2>::SharedPtr
     pointcloud_publisher_;
 
   std::shared_ptr<cube::ErrorModel> error_model_;
+
+  std::string base_link_frame_ = "base_link";
+  std::string level_frame_ = "base_link_north_up";  // level, north-aligned
+  std::string tide_frame_ = "map_tide";
+
+  std::mutex odom_mutex_;
+  float last_vessel_speed_ = std::nanf("");
+  rclcpp::Time last_odom_stamp_{0, 0, RCL_ROS_TIME};
 
   double minimum_range_ = 0.0;  // meters
   double minimum_range_sq_ = minimum_range_ * minimum_range_;

--- a/cube_bathymetry/src/detections_to_pointcloud.cpp
+++ b/cube_bathymetry/src/detections_to_pointcloud.cpp
@@ -29,6 +29,7 @@
 #include "lifecycle_msgs/msg/state.hpp"
 
 #include "cube_bathymetry/error_model.h"
+#include "geometry_msgs/msg/transform_stamped.hpp"
 #include "marine_acoustic_msgs/msg/sonar_detections.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
@@ -131,6 +132,29 @@ private:
     last_odom_stamp_ = msg->header.stamp;
   }
 
+  // Look up target<-source at the ping stamp; if TF is momentarily behind (an
+  // "extrapolation into the future", common under bag replay), fall back to the
+  // latest available transform. Attitude/heave vary slowly, so tens of ms of
+  // staleness is harmless. Returns false only if no transform is available.
+  bool lookupAtOrLatest(
+    const std::string & target, const std::string & source,
+    const rclcpp::Time & stamp, geometry_msgs::msg::TransformStamped & out)
+  {
+    try {
+      out = tf_buffer_->lookupTransform(target, source, stamp);
+      return true;
+    } catch (const tf2::ExtrapolationException &) {
+      try {
+        out = tf_buffer_->lookupTransform(target, source, tf2::TimePointZero);
+        return true;
+      } catch (const tf2::TransformException &) {
+        return false;
+      }
+    } catch (const tf2::TransformException &) {
+      return false;
+    }
+  }
+
   void detectionsCallback(const marine_acoustic_msgs::msg::SonarDetections::UniquePtr & msg)
   {
     cube::Platform platform;
@@ -139,30 +163,29 @@ private:
     const rclcpp::Time stamp(msg->header.stamp);
 
     // Attitude (roll/pitch) from TF at the ping stamp -- the SAME pose used
-    // downstream to place the soundings, so the error budget is coherent, and
-    // it is interpolated to the exact stamp rather than "latest received".
+    // downstream to place the soundings, so the error budget is coherent.
     // Position and heading are not needed by the error model.
-    try {
-      const auto level = tf_buffer_->lookupTransform(level_frame_, base_link_frame_, stamp);
+    geometry_msgs::msg::TransformStamped level;
+    if(lookupAtOrLatest(level_frame_, base_link_frame_, stamp, level)) {
       double y, p, r;
       tf2::getEulerYPR(level.transform.rotation, y, p, r);
       platform.roll = r;
       platform.pitch = p;
       (void)y;  // yaw/heading unused by the error model
-    } catch (const tf2::TransformException & e) {
+    } else {
       RCLCPP_WARN_STREAM_THROTTLE(get_logger(), *get_clock(), 10000,
         "No attitude TF (" << level_frame_ << " <- " << base_link_frame_ <<
-        ") at ping time; roll/pitch = NaN: " << e.what());
+        "); roll/pitch = NaN");
       platform.roll = std::nan("");
       platform.pitch = std::nan("");
     }
 
     // Heave = boat vertical offset from the tide-corrected surface. It enters
     // the budget only squared, so it is non-critical; default to 0 if absent.
-    try {
-      platform.heave = static_cast<float>(tf_buffer_->lookupTransform(
-        tide_frame_, base_link_frame_, stamp).transform.translation.z);
-    } catch (const tf2::TransformException &) {
+    geometry_msgs::msg::TransformStamped tide;
+    if(lookupAtOrLatest(tide_frame_, base_link_frame_, stamp, tide)) {
+      platform.heave = static_cast<float>(tide.transform.translation.z);
+    } else {
       platform.heave = 0.0f;
     }
 

--- a/cube_bathymetry/test/test_error_model.cpp
+++ b/cube_bathymetry/test/test_error_model.cpp
@@ -34,11 +34,8 @@ protected:
   {
     Platform p{};
     p.timestamp = 0.0;
-    p.latitude = 43.07;
-    p.longitude = -70.76;
     p.roll = 0.0f;
     p.pitch = 0.0f;
-    p.heading = 0.0f;
     p.heave = 0.0f;
     p.surf_sspeed = 1500.0f;
     p.mean_speed = 1500.0f;


### PR DESCRIPTION
## Summary

Makes the cube data flow use a **single, coherent pose source**. Two coupled
commits (the second fills the struct the first slims, so they ride together):

1. **Slim `Platform`** — drop `latitude/longitude/heading`. They were inherited
   from Calder's `Platform` (where they fed georeferencing); in this ROS port
   georeferencing is TF's job, so `error_model.cpp` never reads them.
2. **Source pose from TF + odom** in `detections_to_pointcloud`, replacing the
   parallel `NavigationSensors` path:
   - **roll/pitch** from TF (`level_frame ← base_link_frame`) **at the ping
     stamp** — the same pose that places the soundings downstream, interpolated
     to the exact time (vs "latest received within 1 s").
   - **heave** from TF (`tide_frame ← base_link_frame`).z — enters the budget
     only squared, so non-critical; defaults to 0 if absent.
   - **vessel_speed** (SOG) from `/odom` twist.

This removes the two-pose-sources incoherence (#31): the error budget and the
sounding placement now draw from the same TF at the same stamp. Frame names are
params (`base_link_frame`/`level_frame`/`tide_frame`), defaulting to the
unprefixed `mru_transform` names; platform config sets the namespace (e.g.
`bizzy/base_link`). Drops the `mru_transform` dependency.

## Validation

- TF extraction verified against the 2026-06-04 bag: roll ±3°, pitch ~1–2°,
  heave ±2 cm (textbook boat motion).
- **234 package tests pass** (build, cpplint/uncrustify/copyright/flake8/pep257,
  and all gtest suites incl. `test_error_model` 10/10).
- The new TF/odom runtime path is exercised **end-to-end by the offline dry run**
  (step 3 of #31), not by unit tests.

Closes #32. Part of #31 (steps 1 + 2).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
