### PR TITLE
bag_to_geotiff: consume the cloud's per-sounding TPU (drop the placeholder)

### DIFF
--- a/.agent/work-plans/issue-34/progress.md
+++ b/.agent/work-plans/issue-34/progress.md
@@ -1,0 +1,21 @@
+---
+issue: 34
+---
+
+# Issue #34 — bag_to_geotiff: consume the cloud per-sounding TPU
+
+## Integrated Review
+**Status**: complete
+**When**: 2026-06-05 03:30 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**PR**: #35 at `faee084`
+**Sources**: 1 (Copilot R1 @ `c4ad5e4`)
+**Cross-source confirmations**: 0
+**CI**: build-and-test success; copilot-reviewer success
+
+### Findings
+- [x] (valid, Copilot R1) has_tpu set from vertical_uncertainty alone but horizontal iterator built unconditionally -> uncaught throw on a one-field cloud; now requires both fields -- `src/bag_to_geotiff.cpp`
+
+### False positives
+- (Copilot R1) possible past-end TPU iterator read -- a valid PointCloud2's per-point fields share one point_step/data length, so all field iterators have identical count and advance in lockstep; cannot desync.

--- a/cube_bathymetry/src/bag_to_geotiff.cpp
+++ b/cube_bathymetry/src/bag_to_geotiff.cpp
@@ -24,6 +24,7 @@
 #include <chrono>
 #include <cmath>
 #include <limits>
+#include <optional>
 #include <vector>
 
 #include "tf2_ros/buffer.h"
@@ -382,10 +383,30 @@ int main(int argc, char *argv[])
           auto transform = tfBuffer.lookupTransform("earth", msg->header.frame_id,
             msg->header.stamp);
 
+          // Use the cloud's per-sounding TPU (from cube::ErrorModel via
+          // detections_to_pointcloud) when present -- the same data the live
+          // cube_bathymetry_node grid uses. Fall back to the nav-covariance
+          // estimate only for older bags that lack the fields.
+          bool has_tpu = false;
+          for (const auto & f  :  msg->fields) {
+            if (f.name == "vertical_uncertainty") {
+              has_tpu = true;
+              break;
+            }
+          }
+          const double fallback_vert = last_nav.position_covariance[8] * 10.0;
+          const double fallback_horiz = std::max(last_nav.position_covariance[0],
+            last_nav.position_covariance[4]) * 10.0;
+
           std::vector<cube::GeoSounding> soundings;
           sensor_msgs::PointCloud2ConstIterator<float> iter_x(*msg, "x");
           sensor_msgs::PointCloud2ConstIterator<float> iter_y(*msg, "y");
           sensor_msgs::PointCloud2ConstIterator<float> iter_z(*msg, "z");
+          std::optional<sensor_msgs::PointCloud2ConstIterator<float>> iter_vu, iter_hu;
+          if (has_tpu) {
+            iter_vu.emplace(*msg, "vertical_uncertainty");
+            iter_hu.emplace(*msg, "horizontal_uncertainty");
+          }
           for (; (iter_x != iter_x.end()) && (iter_y != iter_y.end()) && (iter_z != iter_z.end());
             ++iter_x, ++iter_y, ++iter_z)
           {
@@ -402,9 +423,15 @@ int main(int argc, char *argv[])
               sounding_ecef.point.z);
             gz4d::GeoPointLatLongDegrees ll(ecef);
             cube::GeoSounding s(ll);
-            s.sounding.vertical_error = last_nav.position_covariance[8] * 10.0;
-            s.sounding.horizontal_error = std::max(last_nav.position_covariance[0],
-              last_nav.position_covariance[4]) * 10.0;
+            if (has_tpu) {
+              s.sounding.vertical_error = **iter_vu;
+              s.sounding.horizontal_error = **iter_hu;
+              ++(*iter_vu);
+              ++(*iter_hu);
+            } else {
+              s.sounding.vertical_error = fallback_vert;
+              s.sounding.horizontal_error = fallback_horiz;
+            }
 
             soundings.push_back(s);
           }

--- a/cube_bathymetry/src/bag_to_geotiff.cpp
+++ b/cube_bathymetry/src/bag_to_geotiff.cpp
@@ -387,13 +387,13 @@ int main(int argc, char *argv[])
           // detections_to_pointcloud) when present -- the same data the live
           // cube_bathymetry_node grid uses. Fall back to the nav-covariance
           // estimate only for older bags that lack the fields.
-          bool has_tpu = false;
+          bool has_vu = false;
+          bool has_hu = false;
           for (const auto & f  :  msg->fields) {
-            if (f.name == "vertical_uncertainty") {
-              has_tpu = true;
-              break;
-            }
+            if (f.name == "vertical_uncertainty") {has_vu = true;}
+            if (f.name == "horizontal_uncertainty") {has_hu = true;}
           }
+          const bool has_tpu = has_vu && has_hu;  // need both, else fall back
           const double fallback_vert = last_nav.position_covariance[8] * 10.0;
           const double fallback_horiz = std::max(last_nav.position_covariance[0],
             last_nav.position_covariance[4]) * 10.0;


### PR DESCRIPTION
## Summary

`bag_to_geotiff` predated the error model and estimated per-sounding uncertainty
from `NavSatFix.position_covariance × 10`, ignoring the
`vertical_uncertainty`/`horizontal_uncertainty` fields that
`detections_to_pointcloud` now writes (via `cube::ErrorModel`). So the offline
GeoTIFF and the live `cube_bathymetry_node` grid disagreed on uncertainty.

Now it reads the cloud's TPU fields when present — the same data the live grider
uses — and falls back to the nav-covariance estimate only for older bags that
lack them.

## Validation

- 234 tests pass (build, cpplint/uncrustify/copyright/flake8/pep257, gtests).
- The offline dry run confirmed `/soundings` carry valid per-ping TPU (0 NaN), so
  band 2 of the GeoTIFF now reflects the real CUBE error budget.

Closes the third step of the data-flow redesign (#31) and the other half of #30.

Closes #34. Part of #31. Related: #30.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
