### PR TITLE
Harden gridding against TF timing + non-finite soundings (closes #36)

### DIFF
--- a/cube_bathymetry/src/cube_bathymetry_node.cpp
+++ b/cube_bathymetry/src/cube_bathymetry_node.cpp
@@ -24,7 +24,7 @@
 #include <string>
 #include <vector>
 
-#include <tf2_ros/transform_listener.h>
+#include "tf2_ros/transform_listener.h"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
@@ -159,8 +159,8 @@ private:
     // carry a depth estimate (a persistently-zero count means soundings arrive
     // but never resolve into the grid).
     RCLCPP_INFO_STREAM_THROTTLE(get_logger(), *get_clock(), 10000,
-      "Published grid: " << populated << " populated cells over "
-      << map_sheet_->grids().size() << " tiles");
+      "Published grid: " << populated << " populated cells over " <<
+      map_sheet_->grids().size() << " tiles");
   }
 
   // Look up target<-source at the exact stamp; on extrapolation (the requested
@@ -209,8 +209,10 @@ private:
     sensor_msgs::msg::PointCloud2 soundings_in_map_frame;
     tf2::doTransform(*msg, soundings_in_map_frame, transform);
 
+    // PointCloud2 point count is width * height (height > 1 for organized clouds).
+    const size_t point_count = static_cast<size_t>(msg->width) * msg->height;
     std::vector<cube::MapSounding> soundings;
-    soundings.reserve(msg->width);
+    soundings.reserve(point_count);
 
     try {
       sensor_msgs::PointCloud2ConstIterator<float> iter_x(soundings_in_map_frame, "x");
@@ -233,14 +235,16 @@ private:
         const float x = *iter_x, y = *iter_y, z = *iter_z;
         const float vu = *iter_vertical_uncertainty, hu = *iter_horizontal_uncertainty;
 
-        // A non-finite position or uncertainty would poison the CUBE estimator:
-        // NaN variance -> NaN depth estimate -> the whole cell drops out of the
-        // published grid. Skip such soundings so one bad input can't blank the
-        // grid. (Upstream cause is usually missing attitude/odom TF -- e.g. the
-        // simulator before its frame params were set -- which makes
-        // detections_to_pointcloud emit NaN uncertainty.)
+        // Drop soundings the CUBE estimator can't use. A non-finite position or
+        // uncertainty -- or a non-positive vertical / negative horizontal
+        // uncertainty (sqrt of which is NaN) -- propagates a NaN variance into
+        // the estimator: NaN depth estimate -> the whole cell drops out of the
+        // published grid. Skipping here keeps the dropped-count diagnostic
+        // honest and matches Grid::insert's guard. (Upstream cause is usually
+        // missing attitude/odom TF -- e.g. the simulator before its frame
+        // params were set -- which makes detections_to_pointcloud emit NaN.)
         if(!std::isfinite(x) || !std::isfinite(y) || !std::isfinite(z) ||
-          !std::isfinite(vu) || !std::isfinite(hu))
+          !std::isfinite(vu) || !std::isfinite(hu) || vu <= 0.0f || hu < 0.0f)
         {
           ++dropped;
           continue;
@@ -254,9 +258,9 @@ private:
 
       if(dropped > 0) {
         RCLCPP_WARN_STREAM_THROTTLE(get_logger(), *get_clock(), 5000,
-          dropped << " of " << msg->width << " soundings dropped (non-finite "
-          "position/uncertainty) -- check attitude/odom TF feeding "
-          << msg->header.frame_id);
+          dropped << " of " << point_count << " soundings dropped (non-finite "
+          "or non-positive position/uncertainty) -- check attitude/odom TF "
+          "feeding " << msg->header.frame_id);
       }
     } catch (const std::exception & e) {
       // Missing field in the cloud, etc. -- don't let it kill the callback.

--- a/cube_bathymetry/src/cube_bathymetry_node.cpp
+++ b/cube_bathymetry/src/cube_bathymetry_node.cpp
@@ -20,6 +20,10 @@
 // THE SOFTWARE.
 
 
+#include <cmath>
+#include <string>
+#include <vector>
+
 #include <tf2_ros/transform_listener.h>
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
@@ -101,6 +105,8 @@ private:
 
     auto bounds = map_sheet_->gridBounds();
     if(isnan(bounds.maximum.x)) {
+      // No tiles populated yet (no soundings have been added). pingCallback
+      // emits the actionable diagnostics for why soundings aren't arriving.
       return;
     }
     auto cell_counts = map_sheet_->totalCellCounts();
@@ -123,6 +129,7 @@ private:
     map.add("elevation");
     map.add("uncertainty");
 
+    size_t populated = 0;
     for (auto grid  :  map_sheet_->grids()) {
       auto origin = grid->origin();
       auto counts = grid->cellCounts();
@@ -139,6 +146,7 @@ private:
             if(map.getIndex(p, index)) {
               map.at("elevation", index) = depth_uncertainty.depth;
               map.at("uncertainty", index) = depth_uncertainty.uncertainty;
+              ++populated;
             }
           }
         }
@@ -146,6 +154,40 @@ private:
     }
     auto message = grid_map::GridMapRosConverter::toMessage(map);
     grid_publisher_->publish(*message);
+
+    // Liveness heartbeat: confirms the grid is being emitted and how many cells
+    // carry a depth estimate (a persistently-zero count means soundings arrive
+    // but never resolve into the grid).
+    RCLCPP_INFO_STREAM_THROTTLE(get_logger(), *get_clock(), 10000,
+      "Published grid: " << populated << " populated cells over "
+      << map_sheet_->grids().size() << " tiles");
+  }
+
+  // Look up target<-source at the exact stamp; on extrapolation (the requested
+  // time is outside the buffered window) fall back to the latest available
+  // transform. The map<-sensor chain includes the position-driven `map`
+  // transform, which on some platforms updates slower (~1 Hz) than the sonar
+  // ping rate (#36), so an exact-stamp lookup routinely extrapolates. Platform
+  // pose varies slowly relative to a ping interval, so the latest transform is
+  // an acceptable placement -- far better than dropping the ping and silently
+  // emptying the grid. Mirrors detections_to_pointcloud (PR #33).
+  bool lookupAtOrLatest(
+    const std::string & target, const std::string & source,
+    const rclcpp::Time & stamp, geometry_msgs::msg::TransformStamped & out)
+  {
+    try {
+      out = tf_buffer_->lookupTransform(target, source, stamp);
+      return true;
+    } catch (const tf2::ExtrapolationException &) {
+      try {
+        out = tf_buffer_->lookupTransform(target, source, tf2::TimePointZero);
+        return true;
+      } catch (const tf2::TransformException &) {
+        return false;
+      }
+    } catch (const tf2::TransformException &) {
+      return false;
+    }
   }
 
   void pingCallback(const sensor_msgs::msg::PointCloud2::UniquePtr & msg)
@@ -154,17 +196,23 @@ private:
       return;
     }
 
+    geometry_msgs::msg::TransformStamped transform;
+    if(!lookupAtOrLatest(map_frame_, msg->header.frame_id,
+        rclcpp::Time(msg->header.stamp), transform))
+    {
+      RCLCPP_WARN_STREAM_THROTTLE(get_logger(), *get_clock(), 5000,
+        "No transform " << map_frame_ << " <- " << msg->header.frame_id <<
+        " (at ping time or latest); dropping ping -- grid will not update");
+      return;
+    }
+
+    sensor_msgs::msg::PointCloud2 soundings_in_map_frame;
+    tf2::doTransform(*msg, soundings_in_map_frame, transform);
+
+    std::vector<cube::MapSounding> soundings;
+    soundings.reserve(msg->width);
+
     try {
-      auto transform = tf_buffer_->lookupTransform(map_frame_, msg->header.frame_id,
-        msg->header.stamp, tf2::durationFromSec(2.0));
-      sensor_msgs::msg::PointCloud2 soundings_in_map_frame;
-      tf2::doTransform(*msg, soundings_in_map_frame, transform);
-
-      std::vector<cube::MapSounding> soundings;
-
-      sensor_msgs::PointCloud2ConstIterator<float> iter_original_z(*msg, "z");
-
-
       sensor_msgs::PointCloud2ConstIterator<float> iter_x(soundings_in_map_frame, "x");
       sensor_msgs::PointCloud2ConstIterator<float> iter_y(soundings_in_map_frame, "y");
       sensor_msgs::PointCloud2ConstIterator<float> iter_z(soundings_in_map_frame, "z");
@@ -173,11 +221,7 @@ private:
       sensor_msgs::PointCloud2ConstIterator<float> iter_horizontal_uncertainty(
         soundings_in_map_frame, "horizontal_uncertainty");
 
-      auto epoch = std::chrono::time_point<std::chrono::steady_clock>{};
-
-      auto timestamp = epoch + std::chrono::seconds(msg->header.stamp.sec) +
-        std::chrono::nanoseconds(msg->header.stamp.nanosec);
-
+      size_t dropped = 0;
       for (; (iter_x != iter_x.end()) &&
         (iter_y != iter_y.end()) &&
         (iter_z != iter_z.end()) &&
@@ -186,23 +230,53 @@ private:
         ++iter_x, ++iter_y, ++iter_z,
         ++iter_vertical_uncertainty, ++iter_horizontal_uncertainty)
       {
-        cube::MapSounding s(*iter_x, *iter_y, *iter_z);
-        s.sounding.vertical_error = *iter_vertical_uncertainty;
-        s.sounding.horizontal_error = *iter_horizontal_uncertainty;
+        const float x = *iter_x, y = *iter_y, z = *iter_z;
+        const float vu = *iter_vertical_uncertainty, hu = *iter_horizontal_uncertainty;
+
+        // A non-finite position or uncertainty would poison the CUBE estimator:
+        // NaN variance -> NaN depth estimate -> the whole cell drops out of the
+        // published grid. Skip such soundings so one bad input can't blank the
+        // grid. (Upstream cause is usually missing attitude/odom TF -- e.g. the
+        // simulator before its frame params were set -- which makes
+        // detections_to_pointcloud emit NaN uncertainty.)
+        if(!std::isfinite(x) || !std::isfinite(y) || !std::isfinite(z) ||
+          !std::isfinite(vu) || !std::isfinite(hu))
+        {
+          ++dropped;
+          continue;
+        }
+
+        cube::MapSounding s(x, y, z);
+        s.sounding.vertical_error = vu;
+        s.sounding.horizontal_error = hu;
         soundings.push_back(s);
       }
 
-      map_sheet_->addSoundings(soundings, timestamp);
-
-      if(last_grid_publish_time_.nanoseconds() == 0 ||
-        rclcpp::Time(msg->header.stamp) - last_grid_publish_time_ >
-        rclcpp::Duration::from_seconds(5.0))
-      {
-        publishGrid();
-        last_grid_publish_time_ = msg->header.stamp;
+      if(dropped > 0) {
+        RCLCPP_WARN_STREAM_THROTTLE(get_logger(), *get_clock(), 5000,
+          dropped << " of " << msg->width << " soundings dropped (non-finite "
+          "position/uncertainty) -- check attitude/odom TF feeding "
+          << msg->header.frame_id);
       }
-    } catch (const tf2::TransformException & e) {
-      RCLCPP_WARN_STREAM(get_logger(), "tf2 exception: " << e.what());
+    } catch (const std::exception & e) {
+      // Missing field in the cloud, etc. -- don't let it kill the callback.
+      RCLCPP_WARN_STREAM_THROTTLE(get_logger(), *get_clock(), 5000,
+        "Could not read soundings cloud: " << e.what());
+      return;
+    }
+
+    auto epoch = std::chrono::time_point<std::chrono::steady_clock>{};
+    auto timestamp = epoch + std::chrono::seconds(msg->header.stamp.sec) +
+      std::chrono::nanoseconds(msg->header.stamp.nanosec);
+
+    map_sheet_->addSoundings(soundings, timestamp);
+
+    if(last_grid_publish_time_.nanoseconds() == 0 ||
+      rclcpp::Time(msg->header.stamp) - last_grid_publish_time_ >
+      rclcpp::Duration::from_seconds(5.0))
+    {
+      publishGrid();
+      last_grid_publish_time_ = msg->header.stamp;
     }
   }
 };

--- a/cube_bathymetry/src/grid.cpp
+++ b/cube_bathymetry/src/grid.cpp
@@ -44,6 +44,21 @@ bool Grid::insert(const std::vector<MapSounding> & soundings)
 
 bool Grid::insert(const MapSounding & sounding)
 {
+  // Reject non-finite soundings at the door. A NaN depth, position, or
+  // uncertainty propagates through the CUBE variance math (gain, predicted
+  // variance) into a NaN hypothesis estimate, which then blanks the cell and,
+  // because medians/queues mix neighbours, can corrupt good data. One bad
+  // sounding must never be able to empty the grid. (Upstream cause is usually
+  // missing attitude/odom TF making the error model emit NaN uncertainty.)
+  if(!std::isfinite(sounding.x) || !std::isfinite(sounding.y) ||
+    !std::isfinite(sounding.sounding.depth) ||
+    !std::isfinite(sounding.sounding.vertical_error) ||
+    !std::isfinite(sounding.sounding.horizontal_error) ||
+    sounding.sounding.vertical_error <= 0.0)
+  {
+    return false;
+  }
+
   double max_variance_allowed = parameters_.iho_fixed + parameters_.iho_percent *
     sounding.sounding.depth * sounding.sounding.depth / (CONF_95PC * CONF_95PC);
   double ratio = max_variance_allowed / sounding.sounding.vertical_error;

--- a/cube_bathymetry/src/grid.cpp
+++ b/cube_bathymetry/src/grid.cpp
@@ -54,8 +54,11 @@ bool Grid::insert(const MapSounding & sounding)
     !std::isfinite(sounding.sounding.depth) ||
     !std::isfinite(sounding.sounding.vertical_error) ||
     !std::isfinite(sounding.sounding.horizontal_error) ||
-    sounding.sounding.vertical_error <= 0.0)
+    sounding.sounding.vertical_error <= 0.0 ||
+    sounding.sounding.horizontal_error < 0.0)
   {
+    // Note: horizontal_error feeds std::sqrt() below, so a negative value
+    // (not just NaN) would reintroduce NaN; reject it here.
     return false;
   }
 

--- a/cube_bathymetry/test/test_grid.cpp
+++ b/cube_bathymetry/test/test_grid.cpp
@@ -21,6 +21,7 @@
 
 #include <gtest/gtest.h>
 #include <cmath>
+#include <limits>
 #include <vector>
 #include "cube_bathymetry/grid.h"
 
@@ -156,6 +157,81 @@ TEST_F(GridTest, InsertVectorOfSoundings)
   }
 
   EXPECT_TRUE(g.insert(soundings));
+}
+
+TEST_F(GridTest, InsertNonFiniteSoundingReturnsFalse)
+{
+  Grid g(CellCounts(10, 10), CellSizes(1.0f), MapPosition(0.0, 0.0), params);
+
+  const float nan = std::numeric_limits<float>::quiet_NaN();
+
+  // NaN depth (e.g. from a NaN attitude in the error model)
+  MapSounding bad_depth(5.0, 5.0, nan);
+  bad_depth.sounding.vertical_error = 0.5f;
+  bad_depth.sounding.horizontal_error = 0.1f;
+  EXPECT_FALSE(g.insert(bad_depth));
+
+  // NaN vertical uncertainty (the value that becomes the CUBE variance)
+  MapSounding bad_vu(5.0, 5.0, -10.0f);
+  bad_vu.sounding.vertical_error = nan;
+  bad_vu.sounding.horizontal_error = 0.1f;
+  EXPECT_FALSE(g.insert(bad_vu));
+
+  // NaN horizontal uncertainty
+  MapSounding bad_hu(5.0, 5.0, -10.0f);
+  bad_hu.sounding.vertical_error = 0.5f;
+  bad_hu.sounding.horizontal_error = nan;
+  EXPECT_FALSE(g.insert(bad_hu));
+
+  // Non-positive variance (a divide-by-zero / negative-variance hazard)
+  MapSounding zero_vu(5.0, 5.0, -10.0f);
+  zero_vu.sounding.vertical_error = 0.0f;
+  zero_vu.sounding.horizontal_error = 0.1f;
+  EXPECT_FALSE(g.insert(zero_vu));
+
+  // Nothing got inserted: the whole grid is still empty.
+  for (const auto & v  : g.values()) {
+    EXPECT_TRUE(std::isnan(v.depth));
+  }
+}
+
+// Regression for #36 / the sim sonar-path break: a single NaN sounding
+// (the symptom of missing attitude/odom TF) must not be able to wipe out a
+// cell already estimated from good soundings.
+TEST_F(GridTest, NonFiniteSoundingDoesNotPoisonGoodData)
+{
+  Grid g(CellCounts(10, 10), CellSizes(1.0f), MapPosition(0.0, 0.0), params);
+
+  for (int i = 0; i < 20; ++i) {
+    MapSounding s(5.0, 5.0, -10.0f);
+    s.sounding.vertical_error = 0.5f;
+    s.sounding.horizontal_error = 0.1f;
+    g.insert(s);
+  }
+
+  // Capture that a populated depth exists before the bad insert.
+  bool had_valid = false;
+  for (const auto & v  : g.values()) {
+    if (!std::isnan(v.depth)) {had_valid = true; break;}
+  }
+  ASSERT_TRUE(had_valid);
+
+  // Inject a NaN-uncertainty sounding at the same location.
+  MapSounding poison(5.0, 5.0, -10.0f);
+  poison.sounding.vertical_error = std::numeric_limits<float>::quiet_NaN();
+  poison.sounding.horizontal_error = 0.1f;
+  EXPECT_FALSE(g.insert(poison));
+
+  // The good estimate survives, finite.
+  bool still_valid = false;
+  for (const auto & v  : g.values()) {
+    if (!std::isnan(v.depth)) {
+      EXPECT_TRUE(std::isfinite(v.depth));
+      EXPECT_TRUE(std::isfinite(v.uncertainty));
+      still_valid = true;
+    }
+  }
+  EXPECT_TRUE(still_valid);
 }
 
 }  // namespace cube

--- a/cube_bathymetry/test/test_grid.cpp
+++ b/cube_bathymetry/test/test_grid.cpp
@@ -189,6 +189,13 @@ TEST_F(GridTest, InsertNonFiniteSoundingReturnsFalse)
   zero_vu.sounding.horizontal_error = 0.1f;
   EXPECT_FALSE(g.insert(zero_vu));
 
+  // Negative horizontal uncertainty: finite, but sqrt(horizontal_error) is NaN,
+  // which would reintroduce the NaN propagation the guard prevents.
+  MapSounding neg_hu(5.0, 5.0, -10.0f);
+  neg_hu.sounding.vertical_error = 0.5f;
+  neg_hu.sounding.horizontal_error = -0.1f;
+  EXPECT_FALSE(g.insert(neg_hu));
+
   // Nothing got inserted: the whole grid is still empty.
   for (const auto & v  : g.values()) {
     EXPECT_TRUE(std::isnan(v.depth));


### PR DESCRIPTION
## What

Hardens `cube_bathymetry` gridding so it no longer silently emits nothing. Two robustness fixes + a diagnostic, prompted by **#36** (empty `m3/grid` on BizzyBoat 2026-06-09 despite active state, 9 Hz soundings, valid placement TF) and the parallel simulator break.

## Diagnosis

Replaying the recorded 2026-06-09 M3 bag (`/bizzy/sensors/m3/soundings` + `/tf` + `/tf_static`) through `cube_bathymetry_node` reproduces a **healthy grid (40 GridMaps, growing extent, elevation+uncertainty layers)**. The recorded soundings are 100% finite. So the gridding logic is correct — the live failure was **TF timing**, and the node had no resilience to it.

## Fixes

1. **Placement lookup falls back to latest on extrapolation** (`lookupAtOrLatest`, mirroring `detections_to_pointcloud` from PR #33). The `map ← sensor` chain includes the position-driven `map` transform, which updates ~1 Hz on the boat vs 9 Hz pings (per #36), so an exact-stamp lookup routinely extrapolates. The old raw 2 s blocking lookup dropped every such ping → grid never built. Pose varies slowly over a ping interval, so the latest transform is an acceptable placement.

2. **Skip non-finite soundings** — in `pingCallback` (drop + throttled warn naming the count and pointing at attitude/odom TF) **and** defensively at the chokepoint `Grid::insert` (reject NaN / non-positive depth, position, or uncertainty). A NaN uncertainty → NaN CUBE variance → NaN cell estimate → the cell drops out; this is exactly how the simulator's missing-frame-params regression silently blanked the grid.

3. **Liveness heartbeat** — `publishGrid` logs populated-cell/tile counts (throttled), so a future empty grid is diagnosable in seconds instead of time-boxed in the field.

## Tests

`test_grid` gains NaN-rejection and no-poisoning-of-good-data cases (9/9 pass; full suite green). Verified end-to-end by bag replay: 40 grids, heartbeat counts climbing 162 → 8591 → 9817 cells.

Closes #36.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
