### PR TITLE
Field import: cube_bathymetry — clear_grid service (2026-06-10)

### DIFF
--- a/cube_bathymetry/CMakeLists.txt
+++ b/cube_bathymetry/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(rclcpp_lifecycle REQUIRED)
 find_package(rosbag2_cpp REQUIRED)
 find_package(rosbag2_transport REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_sensor_msgs REQUIRED)
 
@@ -65,6 +66,7 @@ target_link_libraries(cube_bathymetry_node
   ${grid_map_ros_LIBRARIES}
   rclcpp::rclcpp
   ${sensor_msgs_TARGETS}
+  ${std_srvs_TARGETS}
   tf2_sensor_msgs::tf2_sensor_msgs
 )
 

--- a/cube_bathymetry/package.xml
+++ b/cube_bathymetry/package.xml
@@ -20,6 +20,7 @@
   <depend>rosbag2_transport</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>sensor_msgs</depend>
+  <depend>std_srvs</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_sensor_msgs</depend>
 

--- a/cube_bathymetry/src/cube_bathymetry_node.cpp
+++ b/cube_bathymetry/src/cube_bathymetry_node.cpp
@@ -38,6 +38,7 @@
 #include "tf2_sensor_msgs/tf2_sensor_msgs.hpp"
 #include "grid_map_ros/grid_map_ros.hpp"
 #include "grid_map_msgs/msg/grid_map.hpp"
+#include "std_srvs/srv/trigger.hpp"
 
 
 class CubeBathymetry : public rclcpp_lifecycle::LifecycleNode
@@ -55,13 +56,13 @@ public:
     map_frame_ = this->declare_parameter("map_frame", "map");
 
     declare_parameter("cell_size", 1.0);
-    double cell_size = get_parameter("cell_size").as_double();
+    cell_size_ = get_parameter("cell_size").as_double();
 
     declare_parameter("grid_cell_count", 25);
-    int grid_cell_count = get_parameter("grid_cell_count").as_int();
+    grid_cell_count_ = get_parameter("grid_cell_count").as_int();
 
-    map_sheet_ = std::make_shared<cube::MapSheet>(cube::CellCounts(grid_cell_count),
-      cube::CellSizes(cell_size));
+    map_sheet_ = std::make_shared<cube::MapSheet>(cube::CellCounts(grid_cell_count_),
+      cube::CellSizes(cell_size_));
 
     tf_buffer_ = std::make_unique<tf2_ros::Buffer>(get_clock());
     tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, this);
@@ -72,6 +73,10 @@ public:
     ping_subscription_ = create_subscription<sensor_msgs::msg::PointCloud2>("soundings",
       rclcpp::SensorDataQoS(),
       std::bind(&CubeBathymetry::pingCallback, this, std::placeholders::_1));
+
+    clear_grid_service_ = create_service<std_srvs::srv::Trigger>("clear_grid",
+      std::bind(&CubeBathymetry::clearGridService, this,
+        std::placeholders::_1, std::placeholders::_2));
 
     return rclcpp_lifecycle::LifecycleNode::on_configure(state);
   }
@@ -95,9 +100,13 @@ private:
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 
   std::string map_frame_ = "map";
+  // Cached so clearGrid() can rebuild the sheet with the configured geometry.
+  double cell_size_ = 1.0;
+  int grid_cell_count_ = 25;
   rclcpp::Time last_grid_publish_time_;
   rclcpp_lifecycle::LifecyclePublisher<grid_map_msgs::msg::GridMap>::SharedPtr grid_publisher_;
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr ping_subscription_;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr clear_grid_service_;
 
   void publishGrid()
   {
@@ -161,6 +170,32 @@ private:
     RCLCPP_INFO_STREAM_THROTTLE(get_logger(), *get_clock(), 10000,
       "Published grid: " << populated << " populated cells over " <<
       map_sheet_->grids().size() << " tiles");
+  }
+
+  // Replace the accumulated surface with a fresh, empty sheet of the same
+  // configured geometry. Lets an operator reset the grid in place -- e.g. to
+  // shed a surface that has grown too large for the telemetry downlink -- with
+  // no process restart and no CONFIGURE/ACTIVATE cycle. Safe from a service
+  // callback: main() runs a SingleThreadedExecutor, so this never overlaps
+  // pingCallback's use of map_sheet_.
+  void clearGrid()
+  {
+    map_sheet_ = std::make_shared<cube::MapSheet>(cube::CellCounts(grid_cell_count_),
+      cube::CellSizes(cell_size_));
+    // Force the next ping to republish immediately (a zero-nanosecond time is
+    // the same first-publish trigger used at startup) so the cleared surface
+    // propagates without waiting out the ~5 s publish interval.
+    last_grid_publish_time_ = rclcpp::Time(0, 0, get_clock()->get_clock_type());
+  }
+
+  void clearGridService(
+    const std::shared_ptr<std_srvs::srv::Trigger::Request>/*request*/,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> response)
+  {
+    clearGrid();
+    response->success = true;
+    response->message = "grid cleared";
+    RCLCPP_INFO(get_logger(), "Grid cleared via clear_grid service");
   }
 
   // Look up target<-source at the exact stamp; on extrapolation (the requested

--- a/cube_bathymetry/test/test_map_sheet.cpp
+++ b/cube_bathymetry/test/test_map_sheet.cpp
@@ -143,4 +143,29 @@ TEST_F(MapSheetTest, SpreadSoundingsCreateMultipleGrids)
   EXPECT_GT(ms.grids().size(), 1u);
 }
 
+TEST_F(MapSheetTest, ReconstructClearsAccumulatedData)
+{
+  // Mirror the node's map_sheet_ lifecycle: a shared_ptr replaced wholesale.
+  // This is the invariant clearGrid() (the clear_grid service) relies on --
+  // rebuilding the sheet drops all accumulated soundings and returns to the
+  // empty initial state.
+  auto sheet = std::make_shared<MapSheet>(counts, sizes);
+
+  std::vector<MapSounding> soundings;
+  MapSounding s(5.0, 5.0, -10.0f);
+  s.sounding.vertical_error = 0.5f;
+  s.sounding.horizontal_error = 0.1f;
+  soundings.push_back(s);
+  sheet->addSoundings(soundings);
+
+  ASSERT_FALSE(sheet->grids().empty());
+  ASSERT_TRUE(valid(sheet->gridBounds()));
+
+  // What clearGrid() does: swap in a fresh sheet of the same geometry.
+  sheet = std::make_shared<MapSheet>(counts, sizes);
+
+  EXPECT_TRUE(sheet->grids().empty());
+  EXPECT_FALSE(valid(sheet->gridBounds()));
+}
+
 }  // namespace cube


### PR DESCRIPTION
Field import of the `clear_grid` service added on the boat during the 2026-06-10 deployment (rolker/unh_echoboats_project11#250).

Adds a `std_srvs/srv/Trigger` **`clear_grid`** service that rebuilds `map_sheet_` empty in place (same configured geometry) and forces an immediate republish — an operator mitigation to shed a CUBE surface that has grown too large for the `udp_bridge` downlink, without a process restart or lifecycle cycle. Built, deployed, and verified live on the boat.

Branched **from** `gitcloud/jazzy` (field SHA `64e907d` preserved — no cherry-pick), so origin and the field remote stay reconcilable without a force-push.

Pre-review notes and the one advisory finding (test covers the `MapSheet` rebuild invariant, not the service handler directly) are in the issue.

Durable fix (bounded tile-sync downlink) tracked separately under rolker/unh_marine_autonomy#86; this PR is the manual stopgap we're relying on for the June survey.

Closes #39

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
