### PR TITLE
Adapt to gz4d-free GGGS API; distance via geodesy Vincenty

### DIFF
--- a/cube_bathymetry/CMakeLists.txt
+++ b/cube_bathymetry/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(lifecycle_msgs)
 find_package(marine_acoustic_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)  # odometry for speed-over-ground
 find_package(marine_autonomy REQUIRED)
+find_package(geodesy REQUIRED)  # WGS84 Vincenty inverse (geo_grid distance)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(rosbag2_cpp REQUIRED)
@@ -46,6 +47,8 @@ target_link_libraries(cube_bathymetry
   ${marine_acoustic_msgs_TARGETS}
   marine_autonomy::marine_autonomy
 )
+# geodesy (geographic_info) exports via ament, not a namespaced target.
+ament_target_dependencies(cube_bathymetry geodesy)
 
 install(TARGETS cube_bathymetry EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib

--- a/cube_bathymetry/package.xml
+++ b/cube_bathymetry/package.xml
@@ -16,6 +16,7 @@
   <depend>marine_acoustic_msgs</depend>
   <depend>nav_msgs</depend>  <!-- odometry for speed-over-ground -->
   <depend>marine_autonomy</depend>
+  <depend>geodesy</depend>
   <depend>rclcpp</depend>
   <depend>rosbag2_transport</depend>
   <depend>rclcpp_lifecycle</depend>

--- a/cube_bathymetry/src/geo_grid.cpp
+++ b/cube_bathymetry/src/geo_grid.cpp
@@ -22,6 +22,9 @@
 
 #include "cube_bathymetry/geo_grid.h"
 #include <cmath>
+#include "geodesy/geodesics.h"
+#include "geodesy/wgs84_ellipsoid.h"
+#include "marine_autonomy/gz4d_geo.h"
 
 namespace cube
 {
@@ -70,11 +73,22 @@ bool GeoGrid::insert(const GeoSounding & geo_sounding)
 
   auto bounds = gz4d::BoundsDegrees::radiusFromCenter(geo_sounding, radius);
 
-  gggs::CellAreaIterator i(index_, bounds);
+  // The GGGS CellAreaIterator now takes geographic_msgs GeoPoint corners
+  // (gz4d retired from the GGGS API, unh_marine_autonomy#144). cube keeps
+  // gz4d internally for radiusFromCenter and converts the corners here.
+  gggs::CellAreaIterator i(index_,
+    gggs::geoPoint(bounds.minimum().latitude, bounds.minimum().longitude),
+    gggs::geoPoint(bounds.maximum().latitude, bounds.maximum().longitude));
+
+  // CellIndex::position() returns a GeoPoint; distance to the sounding now
+  // comes from geodesy's WGS84 Vincenty inverse (replacing the gz4d
+  // Position::distanceFrom() the GeoPoint type doesn't provide).
+  const auto sounding_point =
+    gggs::geoPoint(geo_sounding.latitude, geo_sounding.longitude);
 
   bool inserted = false;
   while(i.valid()) {
-    auto distance = i->position().distanceFrom(geo_sounding);
+    auto distance = geodesy::wgs84::inverse(i->position(), sounding_point).distance;
     if(distance < radius) {
       if(!nodes_[*i]) {
         nodes_[*i] = std::make_shared<Node>();

--- a/cube_bathymetry/src/geo_map_sheet.cpp
+++ b/cube_bathymetry/src/geo_map_sheet.cpp
@@ -23,6 +23,7 @@
 #include "cube_bathymetry/geo_map_sheet.h"
 #include <cmath>
 #include <iostream>
+#include "marine_autonomy/gz4d_geo.h"
 
 namespace cube
 {
@@ -68,8 +69,11 @@ std::vector<std::shared_ptr<GeoGrid>> GeoMapSheet::getOrCreateGridsIn(
 {
   std::vector<std::shared_ptr<GeoGrid>> ret;
 
-  gggs::GridAreaIterator i(grid_level_.gridIndex(bounds.minimum()),
-    grid_level_.gridIndex(bounds.maximum()));
+  // gridIndex now takes lat/lon doubles (gz4d retired from the GGGS API,
+  // unh_marine_autonomy#144); bounds remains a gz4d type internally.
+  gggs::GridAreaIterator i(
+    grid_level_.gridIndex(bounds.minimum().latitude, bounds.minimum().longitude),
+    grid_level_.gridIndex(bounds.maximum().latitude, bounds.maximum().longitude));
 
   while(i.valid()) {
     if(!grids_[*i]) {


### PR DESCRIPTION
Closes #41.

Lockstep consumer update for the GGGS public-API migration off gz4d → `geographic_msgs/GeoPoint` (rolker/unh_marine_autonomy#144). **Must merge together with that PR** — cube cannot build against the new GGGS API until #144 lands, and #144's GGGS change cannot land without this.

## Changes

- **`src/geo_map_sheet.cpp`** — `grid_level_.gridIndex(bounds.minimum())` → the existing `(double, double)` overload (`gridIndex(min.latitude, min.longitude)`), since `gridIndex` no longer takes a gz4d position.
- **`src/geo_grid.cpp`** (CUBE insert hot loop):
  - `CellAreaIterator(index_, bounds)` → constructed from two `GeoPoint` corners (derived from the gz4d `radiusFromCenter` bounds cube still computes internally).
  - `i->position().distanceFrom(geo_sounding)` → `geodesy::wgs84::inverse(i->position(), sounding_point).distance`. `CellIndex::position()` now returns a `GeoPoint`, which has no `distanceFrom` (that was a `gz4d::Position` method); geodesy's WGS84 Vincenty inverse is the equivalent, and advances the gz4d retirement rather than re-introducing a gz4d convert.
- **`CMakeLists.txt` / `package.xml`** — add the `geodesy` dependency.
- Added explicit `#include "marine_autonomy/gz4d_geo.h"` where cube uses gz4d types directly (`radiusFromCenter`, `BoundsDegrees`) rather than relying on the GGGS API's (now-removed-from-API) transitive include.

## Out of scope

cube's **internal** gz4d usage is unchanged — `GeoSounding : public gz4d::PositionDegrees`, `gz4d::BoundsDegrees::radiusFromCenter`, and `GeoMapSheet::getOrCreateGridsIn(const gz4d::BoundsDegrees&)`'s own signature. Removing those is a separate, deeper cube gz4d-retirement.

## Verification

Built against the #144 GGGS API (marine_autonomy install overlaid). **221 tests, 0 failures** — including `test_geo_grid.MultipleSoundingsConverge`, whose CUBE convergence depends on the per-cell distance weighting, confirming the Vincenty distance is behaviorally equivalent to the old gz4d `ellipsoid::inverse` (both WGS84).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
