### PR TITLE
fix: profile_err SVP double-square + max_variance_allowed precedence (#46)

### DIFF
--- a/.agent/work-plans/issue-46/progress.md
+++ b/.agent/work-plans/issue-46/progress.md
@@ -1,0 +1,24 @@
+---
+issue: 46
+---
+
+# Issue #46 — Two numeric bugs vs Calder reference: profile_err svp variance double-squared + max_variance_allowed precedence
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-20 10:51 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-46 at `3830646`
+**Mode**: pre-push
+**Depth**: Standard (reason: small diff but touches core error-model/grid estimation paths)
+**Must-fix**: 0 | **Suggestions**: 1 (addressed inline)
+
+Specialists: static analysis (ament_cpplint + ament_uncrustify, clean) · two disjoint-lens
+Claude adversarial passes (both clean, fixes verified against Calder's `errmod_full.c` /
+`cube_grid.c`). Both regression tests independently confirmed to FAIL with the bugs
+reintroduced. 240 tests, 0 failures.
+
+### Findings
+- [x] (suggestion) test comment understated that net carries two quadratic svp terms (profile_err + ang_svp) — clarified — `cube_bathymetry/test/test_error_model.cpp:200`

--- a/cube_bathymetry/include/cube_bathymetry/parameters.h
+++ b/cube_bathymetry/include/cube_bathymetry/parameters.h
@@ -70,6 +70,13 @@ namespace cube
     void setIHOLimits(std::string order);
     void setGridResolution(CellSizes sizes);
 
+  /// Maximum allowable propagation variance for a sounding at the given depth:
+  /// (iho_fixed + iho_percent*depth^2) / CONF_95PC^2.  The *whole* IHO numerator
+  /// is divided by CONF_95PC^2 (Calder, cube_grid.c:1909-1911).  Kept in one place
+  /// so the operator-precedence trap that dropped iho_fixed out of the division
+  /// (#46) cannot recur in the two grid call sites.
+    double maxVarianceAllowed(double depth) const;
+
   /// Value used to indicate 'no data' (typ. FLT_MAX)
     float no_data_value = std::numeric_limits < float > ::quiet_NaN();
 

--- a/cube_bathymetry/src/error_model.cpp
+++ b/cube_bathymetry/src/error_model.cpp
@@ -300,7 +300,11 @@ double ErrorModel::horizontal_positioning_error(
 {
   double meas_angle = beam_angle(detections, i);
 
-  double profile_err = static_error_sources_.sound_speed_profile_variance * sounding.depth /
+  // Calder forms this term from the SVP standard deviation (svp_sdev) and then
+  // squares once (errmod_full.c:663-664). sound_speed_profile_variance is already
+  // svp_sdev^2, so using it here and squaring the whole expression would carry
+  // svp_sdev^4. Use svp_sdev directly. See #46.
+  double profile_err = vessel_.svp_sdev * sounding.depth /
     (platform.mean_speed * cos(meas_angle));
   profile_err *= profile_err;
 

--- a/cube_bathymetry/src/geo_grid.cpp
+++ b/cube_bathymetry/src/geo_grid.cpp
@@ -47,8 +47,7 @@ bool GeoGrid::insert(const std::vector<GeoSounding> & soundings)
 bool GeoGrid::insert(const GeoSounding & geo_sounding)
 {
   const Sounding & sounding = geo_sounding.sounding;
-  double max_variance_allowed = parameters_.iho_fixed + parameters_.iho_percent * sounding.depth *
-    sounding.depth / (CONF_95PC * CONF_95PC);
+  double max_variance_allowed = parameters_.maxVarianceAllowed(sounding.depth);
   double ratio = max_variance_allowed / sounding.vertical_error;
 
   /* Ensure some spreading on point */

--- a/cube_bathymetry/src/grid.cpp
+++ b/cube_bathymetry/src/grid.cpp
@@ -62,8 +62,7 @@ bool Grid::insert(const MapSounding & sounding)
     return false;
   }
 
-  double max_variance_allowed = parameters_.iho_fixed + parameters_.iho_percent *
-    sounding.sounding.depth * sounding.sounding.depth / (CONF_95PC * CONF_95PC);
+  double max_variance_allowed = parameters_.maxVarianceAllowed(sounding.sounding.depth);
   double ratio = max_variance_allowed / sounding.sounding.vertical_error;
 
   /* Ensure some spreading on point */

--- a/cube_bathymetry/src/parameters.cpp
+++ b/cube_bathymetry/src/parameters.cpp
@@ -62,6 +62,11 @@ void Parameters::setIHOLimits(std::string order)
   iho_percent *= iho_percent;
 }
 
+double Parameters::maxVarianceAllowed(double depth) const
+{
+  return (iho_fixed + iho_percent * depth * depth) / (CONF_95PC * CONF_95PC);
+}
+
 void Parameters::setGridResolution(CellSizes sizes)
 {
   /* Compute distance scale based on node spacing */

--- a/cube_bathymetry/test/test_error_model.cpp
+++ b/cube_bathymetry/test/test_error_model.cpp
@@ -188,4 +188,47 @@ TEST_F(ErrorModelTest, EmptyDetectionsReturnsEmpty)
   EXPECT_TRUE(soundings.empty());
 }
 
+// Regression for #46 bug 1: the horizontal sound-speed-profile term (Eqn 3.77)
+// must scale as svp_sdev^2 (a variance), not svp_sdev^4. The original double-
+// squared it (used sound_speed_profile_variance = svp_sdev^2 and then squared the
+// whole expression). Every horizontal term that depends on the SVP error scales as
+// svp_sdev^2 in the correct model, so the SVP-dependent part of horizontal_error
+// must be exactly quadratic: net(2s) == 4*net(s). The bug makes it grow faster.
+TEST_F(ErrorModelTest, ProfileErrorScalesQuadraticallyWithSvp)
+{
+  auto platform = makePlatform();
+  // Off-nadir beam so the profile and ang_svp terms are active (both vanish at
+  // nadir). pitch=0 keeps the geometry simple.
+  auto det = makeDetections({0.6f}, 0.02f);
+
+  // Isolate svp_sdev: zero every other horizontal-error contributor so the only
+  // svp-dependent terms left are profile_err (the fixed one) and ang_svp (inside
+  // swath_angle_error), and float cancellation in the net() subtraction stays
+  // negligible.
+  auto horizontalError = [&](double svp) {
+      Vessel v{};
+      v.gps_off_sdev = 0.0; v.gps_latency_sdev = 0.0; v.gps_drms = 0.0;
+      v.gps_latency = 0.0; v.imu_off_sdev = 0.0; v.imu_rp_align_sdev = 0.0;
+      v.imu_g_align_sdev = 0.0; v.imu_latency_sdev = 0.0; v.tx_latency_sdev = 0.0;
+      v.roll_sdev = 0.0; v.pitch_sdev = 0.0; v.gyro_sdev = 0.0;
+      v.surf_ss_sdev = 0.0; v.sog_sdev = 0.0;
+      v.svp_sdev = svp;
+      Device d{};
+      d.across_track_beamwidth = 0.0;  // kill the beamwidth angle term (ang_meas)
+      ErrorModel em(v, d);
+      auto soundings = em.compute(det, platform);
+      return static_cast<double>(soundings.at(0).horizontal_error);
+    };
+
+  const double he0 = horizontalError(0.0);  // svp-independent baseline
+  const double net1 = horizontalError(1.0) - he0;
+  const double net2 = horizontalError(2.0) - he0;
+
+  ASSERT_GT(net1, 0.0);  // the svp terms genuinely contribute at this beam angle
+  // Both surviving svp terms are quadratic in svp_sdev in the correct model, so
+  // their sum is too: net2 == 4*net1. The bug makes profile_err quartic, which
+  // pushes the ratio to ~13.6.
+  EXPECT_NEAR(net2, 4.0 * net1, 1e-3 * net1);
+}
+
 }  // namespace cube

--- a/cube_bathymetry/test/test_hypothesis.cpp
+++ b/cube_bathymetry/test/test_hypothesis.cpp
@@ -184,4 +184,21 @@ TEST_F(HypothesisTest, MultipleUpdatesConverge)
   EXPECT_LT(h.current_variance, 0.5);
 }
 
+// Characterization (#30): the port computes |error| up front, collapsing Calder's
+// signed +/- 2*h*error monitor branches into one. That is behavior-preserving only
+// if the monitor is symmetric in the sign of the deviation. Symmetric deviations
+// about the prediction must give identical accept/reject, Bayes factor and runlength.
+TEST_F(HypothesisTest, MonitorIsSymmetricInErrorSign)
+{
+  Hypothesis h_plus(10.0f, 1.0f);
+  Hypothesis h_minus(10.0f, 1.0f);
+
+  bool r_plus = h_plus.monitor(10.0f + 2.5f, 1.0f, params);
+  bool r_minus = h_minus.monitor(10.0f - 2.5f, 1.0f, params);
+
+  EXPECT_EQ(r_plus, r_minus);
+  EXPECT_DOUBLE_EQ(h_plus.cumulative_bayes_factor, h_minus.cumulative_bayes_factor);
+  EXPECT_EQ(h_plus.sequence_length, h_minus.sequence_length);
+}
+
 }  // namespace cube

--- a/cube_bathymetry/test/test_parameters.cpp
+++ b/cube_bathymetry/test/test_parameters.cpp
@@ -126,4 +126,31 @@ TEST(ParametersTest, DefaultParameterValues)
   EXPECT_EQ(p.extractor, CUBE_LHOOD);
 }
 
+// Regression for #46 bug 2: the whole IHO numerator (iho_fixed + iho_percent*z^2)
+// must be divided by CONF_95PC^2 -- not just the depth-dependent term. The two grid
+// call sites previously relied on operator precedence, which left iho_fixed outside
+// the division. This pins the corrected value via the shared helper.
+TEST(ParametersTest, MaxVarianceAllowedDividesWholeNumerator)
+{
+  Parameters p(CellSizes(1.0f), "order1a");  // iho_fixed=0.25, iho_percent=1.69e-4
+  const double conf2 = 1.96 * 1.96;          // CONF_95PC^2 = 3.8416
+
+  // depth=0 isolates the fixed term: correct = iho_fixed/conf2 = 0.0651,
+  // whereas the precedence bug would return iho_fixed = 0.25 undivided.
+  EXPECT_NEAR(p.maxVarianceAllowed(0.0), 0.25 / conf2, 1e-9);
+  EXPECT_GT(std::abs(p.maxVarianceAllowed(0.0) - 0.25), 0.18);  // far from the bug value
+
+  // depth=100: (0.25 + 1.69) / 3.8416 = 0.50500, not the bug value
+  // 0.25 + 1.69/3.8416 = 0.68992.
+  EXPECT_NEAR(p.maxVarianceAllowed(100.0), 0.50500, 1e-4);
+  const double bug_value = p.iho_fixed + p.iho_percent * 100.0 * 100.0 / conf2;
+  EXPECT_NEAR(bug_value, 0.68992, 1e-4);  // documents what the precedence bug produced
+  EXPECT_GT(std::abs(p.maxVarianceAllowed(100.0) - bug_value), 0.18);
+
+  // Numerator scales with depth^2 inside the single division.
+  EXPECT_NEAR(
+    p.maxVarianceAllowed(50.0),
+    (p.iho_fixed + p.iho_percent * 50.0 * 50.0) / conf2, 1e-12);
+}
+
 }  // namespace cube


### PR DESCRIPTION
## Summary

Fixes the two numeric bugs found by the static comparison of this port against
Brian Calder's original CUBE C (see #30), plus regression + characterization tests.
The CUBE estimator itself is a faithful port; these two were the only outright bugs.

### Bug 1 — horizontal `profile_err` carried `svp_sdev⁴`
`error_model.cpp` (Eqn 3.77) used `sound_speed_profile_variance` (= `svp_sdev²`) and
then squared the whole expression. Calder forms the term from the **std-dev** and
squares once (`errmod_full.c:663-664`). Now uses `vessel_.svp_sdev` directly. The
vertical (`:256`) and angle (`:211`) paths correctly use the variance and are
unchanged.

### Bug 2 — `max_variance_allowed` precedence dropped `iho_fixed` out of the division
The inline expression in `grid.cpp` and `geo_grid.cpp` divided only the depth term
by `CONF_95PC²`; Calder divides the whole numerator (`cube_grid.c:1909-1911`).
Extracted into `Parameters::maxVarianceAllowed(depth)` so the single correct
division is shared by both call sites and the precedence trap cannot recur.

## Tests
- `ParametersTest.MaxVarianceAllowedDividesWholeNumerator` — pins corrected values
  (depth 0 → `iho_fixed/CONF²`; depth 100 → 0.50500, not the bug's 0.68992).
- `ErrorModelTest.ProfileErrorScalesQuadraticallyWithSvp` — asserts the
  SVP-dependent horizontal error is quadratic (svp²), not quartic.
- `HypothesisTest.MonitorIsSymmetricInErrorSign` — characterizes the faithful core
  (the `|error|` monitor refactor is behavior-preserving).

**Both regression tests were verified to FAIL with the bugs reintroduced.**
240 tests, 0 failures. Pre-push review (static analysis + two disjoint-lens Claude
adversarial passes) came back approved; both passes verified the fixes against
Calder's source.

## Notes
The remaining (non-bug) divergences from Calder are tracked separately:
#47 (error-model fidelity — tide flag, device params, divergences doc), #48
(predicted-surface / guided-disambiguation subsystem), #49 (node extraction quality).

Closes #46

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
