### PR TITLE
Preserve backscatter: carry intensity into the soundings point cloud (#52)

### DIFF
--- a/.agent/work-plans/issue-52/progress.md
+++ b/.agent/work-plans/issue-52/progress.md
@@ -1,0 +1,26 @@
+---
+issue: 52
+---
+
+# Issue #52 — Preserve backscatter: carry SonarDetections intensity into the soundings point cloud
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-20 17:47 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-52 at `3e89ec0`
+**Mode**: pre-push
+**Depth**: Light (reason: small, single-field passthrough; consumers read by field name)
+**Must-fix**: 0 | **Suggestions**: 0
+
+Static analysis (ament_cpplint + ament_uncrustify) clean. One Claude adversarial pass:
+clean — verified field/offset/point_step bookkeeping (24, stride 6), the intensity
+population path through ErrorModel::compute, and that both consumers
+(cube_bathymetry_node, bag_to_geotiff) read strictly by field name so the reorder is
+safe. M3 source verified to populate intensities (kongsberg_em_bridge reflectivity_db).
+247 tests, 0 failures (+2 new: CarriesPerBeamIntensity, IntensityIsNaNWhenAbsent).
+
+### Findings
+- [ ] No issues found. LGTM.

--- a/README.md
+++ b/README.md
@@ -12,10 +12,15 @@ It is based on Brian Calder's original c code found [here](https://bitbucket.org
 | `cube_bathymetry_node` | `soundings` (`sensor_msgs/PointCloud2`) | `grid` (`grid_map_msgs/GridMap`, layers `elevation` + `uncertainty`) | Transforms soundings into `map_frame` via TF, runs the live CUBE estimator, and emits the gridded surface consumed by CAMP / rviz. Lifecycle node. |
 | `bag_to_geotiff` | (offline, reads a bag) | GeoTIFF on disk | Offline gridding tool. |
 
-`soundings` carries five `float32` fields per point: `x`, `y`, `z`,
-`vertical_uncertainty`, `horizontal_uncertainty`. The positions are in the
-detections' own frame (`header.frame_id`); `cube_bathymetry_node` georeferences
-them with a TF lookup `map_frame ← header.frame_id` at the ping stamp.
+`soundings` carries six `float32` fields per point, in order: `x`, `y`, `z`,
+`intensity`, `vertical_uncertainty`, `horizontal_uncertainty`. `intensity` is the
+per-beam acoustic backscatter copied from `SonarDetections.intensities` — usually
+uncalibrated, but reflectivity in dB for the Kongsberg M3 (via `kongsberg_em_bridge`);
+it is `NaN` when the source omits intensities. The positions are in the detections'
+own frame (`header.frame_id`); `cube_bathymetry_node` georeferences them with a TF
+lookup `map_frame ← header.frame_id` at the ping stamp. Consumers read fields **by
+name** (`cube_bathymetry_node` and `bag_to_geotiff` both use named PointCloud2
+iterators), so the field order is not load-bearing.
 
 ## Data flow & pose sourcing (design: #31)
 

--- a/cube_bathymetry/include/cube_bathymetry/sounding.h
+++ b/cube_bathymetry/include/cube_bathymetry/sounding.h
@@ -48,6 +48,14 @@ namespace cube
     sonar_relative_position.x = range * -sin(tx_angle);
     sonar_relative_position.y = range * sin(detections.rx_angles[i]);
     sonar_relative_position.z = range * cos(tx_angle) * cos(detections.rx_angles[i]);
+
+    // Per-beam acoustic intensity (backscatter). Sonar-reported and usually
+    // uncalibrated; for the Kongsberg M3 (via kongsberg_em_bridge) it is
+    // reflectivity in dB. Left NaN when the source omits intensities so a
+    // missing value is never mistaken for a real measurement.
+    if(i < detections.intensities.size()) {
+        intensity = detections.intensities[i];
+    }
     }
 
   /// Depth relative to the sea surface. Positive is up above sea surface
@@ -55,6 +63,9 @@ namespace cube
     float depth = std::nan("");
     float vertical_error = 0.0;
     float horizontal_error = 0.0;
+
+  /// Per-beam acoustic intensity / backscatter (NaN when not reported).
+    float intensity = std::nan("");
 
   // Position relative to the sonar head, in meters.
   // For a typical down looking sonar, x is along the heading, y is to starboard, and z is down.

--- a/cube_bathymetry/src/detections_to_pointcloud.cpp
+++ b/cube_bathymetry/src/detections_to_pointcloud.cpp
@@ -267,12 +267,15 @@ private:
 
     pointcloud.height = 1;
     pointcloud.width = soundings.size();
-    pointcloud.point_step = 20;  // 5 fields * 4 bytes each
+    pointcloud.point_step = 24;  // 6 fields * 4 bytes each
     pointcloud.row_step = pointcloud.point_step * pointcloud.width;
     pointcloud.is_dense = true;
     pointcloud.is_bigendian = false;
 
-    pointcloud.fields.resize(5);
+    // Field order: x, y, z, intensity, vertical_uncertainty, horizontal_uncertainty.
+    // intensity (per-beam backscatter) sits with the geometry, ahead of the
+    // uncertainty fields. Consumers read by field name, so the order is safe.
+    pointcloud.fields.resize(6);
     pointcloud.fields[0].name = "x";
     pointcloud.fields[0].offset = 0;
     pointcloud.fields[0].datatype = sensor_msgs::msg::PointField::FLOAT32;
@@ -285,14 +288,18 @@ private:
     pointcloud.fields[2].offset = 8;
     pointcloud.fields[2].datatype = sensor_msgs::msg::PointField::FLOAT32;
     pointcloud.fields[2].count = 1;
-    pointcloud.fields[3].name = "vertical_uncertainty";
+    pointcloud.fields[3].name = "intensity";
     pointcloud.fields[3].offset = 12;
     pointcloud.fields[3].datatype = sensor_msgs::msg::PointField::FLOAT32;
     pointcloud.fields[3].count = 1;
-    pointcloud.fields[4].name = "horizontal_uncertainty";
+    pointcloud.fields[4].name = "vertical_uncertainty";
     pointcloud.fields[4].offset = 16;
     pointcloud.fields[4].datatype = sensor_msgs::msg::PointField::FLOAT32;
     pointcloud.fields[4].count = 1;
+    pointcloud.fields[5].name = "horizontal_uncertainty";
+    pointcloud.fields[5].offset = 20;
+    pointcloud.fields[5].datatype = sensor_msgs::msg::PointField::FLOAT32;
+    pointcloud.fields[5].count = 1;
 
     pointcloud.data.resize(pointcloud.row_step * pointcloud.height);
     float * data_ptr = reinterpret_cast<float *>(pointcloud.data.data());
@@ -301,9 +308,10 @@ private:
       data_ptr[0] = sounding.sonar_relative_position.x;
       data_ptr[1] = sounding.sonar_relative_position.y;
       data_ptr[2] = sounding.sonar_relative_position.z;
-      data_ptr[3] = sounding.vertical_error;
-      data_ptr[4] = sounding.horizontal_error;
-      data_ptr += 5;  // Move to the next point
+      data_ptr[3] = sounding.intensity;
+      data_ptr[4] = sounding.vertical_error;
+      data_ptr[5] = sounding.horizontal_error;
+      data_ptr += 6;  // Move to the next point
     }
 
     pointcloud_publisher_->publish(pointcloud);

--- a/cube_bathymetry/test/test_error_model.cpp
+++ b/cube_bathymetry/test/test_error_model.cpp
@@ -454,4 +454,36 @@ TEST_F(ErrorModelTest, DefaultsInsideIHOOrder1aBudget)
   }
 }
 
+// --- #52: per-beam backscatter carried into the sounding ----------------------
+
+// compute() must copy SonarDetections.intensities[i] onto each sounding so the
+// downstream point cloud can publish a backscatter field (x,y,z,intensity,...).
+TEST_F(ErrorModelTest, CarriesPerBeamIntensity)
+{
+  ErrorModel em(vessel, device);
+  auto platform = makePlatform();
+  auto det = makeDetections({-0.2f, 0.0f, 0.2f}, 0.02f);
+  det.intensities = {-12.5f, -20.0f, -8.0f};  // e.g. reflectivity, dB
+
+  auto soundings = em.compute(det, platform);
+  ASSERT_EQ(soundings.size(), 3u);
+  EXPECT_FLOAT_EQ(soundings[0].intensity, -12.5f);
+  EXPECT_FLOAT_EQ(soundings[1].intensity, -20.0f);
+  EXPECT_FLOAT_EQ(soundings[2].intensity, -8.0f);
+}
+
+// When the source omits intensities the field must be NaN, never a fabricated
+// value (so a missing measurement is distinguishable downstream).
+TEST_F(ErrorModelTest, IntensityIsNaNWhenAbsent)
+{
+  ErrorModel em(vessel, device);
+  auto platform = makePlatform();
+  auto det = makeDetections({0.0f}, 0.02f);  // no intensities populated
+  ASSERT_TRUE(det.intensities.empty());
+
+  auto soundings = em.compute(det, platform);
+  ASSERT_EQ(soundings.size(), 1u);
+  EXPECT_TRUE(std::isnan(soundings[0].intensity));
+}
+
 }  // namespace cube


### PR DESCRIPTION
## Summary

Carry the per-beam acoustic intensity (backscatter) that
`marine_acoustic_msgs/SonarDetections` already provides through
`detections_to_pointcloud` and onto the soundings `PointCloud2`, instead of
dropping it. First link in preserving backscatter through the bathy pipeline.

## Change
- `cube::Sounding` gains a `float intensity` (NaN default), populated in its
  `(detections, i, depth)` constructor from `detections.intensities[i]` (NaN when
  the source omits it).
- `detections_to_pointcloud` now emits a **6-field** cloud, order
  `x, y, z, intensity, vertical_uncertainty, horizontal_uncertainty`
  (`point_step` 20 → 24).
- README updated. Consumers (`cube_bathymetry_node`, `bag_to_geotiff`) already read
  fields **by name**, so the reorder is safe and they ignore the new field.

## Source verified
For the Kongsberg M3 the value is **reflectivity in dB** — `kongsberg_em_bridge`
populates `SonarDetections.intensities` from the EM datagram
(`node.py:363`, `em_datagrams.py:126`). Real backscatter, co-registered with bathy.

## Scope
This is the cloud-field plumbing only. Aggregating intensity into the CUBE grid
layer and carrying it into the GeoMapSheet/data store (unh_marine_autonomy#86/#180)
are deliberate follow-ons.

## Tests
`CarriesPerBeamIntensity` (intensity copied per beam) and `IntensityIsNaNWhenAbsent`.
247 tests, 0 failures. Pre-push review (static + Claude adversarial) approved, no
findings.

Closes #52

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
