### PR TITLE
Bag-replay store importer: detections bag -> CUBE -> epoch import (import_bag) (#57)

### DIFF
--- a/.agent/work-plans/issue-57/progress.md
+++ b/.agent/work-plans/issue-57/progress.md
@@ -1,0 +1,29 @@
+---
+issue: 57
+---
+
+# Issue #57 — Bag-replay store importer: detections bag -> CUBE GeoMapSheet -> epoch import (PR-B of unh_marine_autonomy#147)
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-21 10:54 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved
+**Round**: 1
+**Ship**: recommended
+
+**Branch**: feature/issue-57 at `b247a7c`
+**Mode**: pre-push
+**Depth**: Deep (reason: new cross-repo offline tool + GeoGrid->store-tile conversion + new lib target)
+**Must-fix**: 1 (resolved) | **Suggestions**: 2 (1 fixed, 1 filed as follow-up)
+
+Two disjoint-lens Claude adversarial passes. Lens A: CLEAN — the load-bearing
+values()<->CellAreaIterator lockstep conversion VERIFIED correct (same single-arg
+iterator, same bounds/order; values() cached once; NaN skipped; float->double), determinism
+holds, replay chain mirrors bag_to_geotiff -d, 3 tests genuinely pin it. Lens B: 1 must-fix
+(store dependency leaked into the core lib -> runtime nodes) + 2 suggestions. 285 tests pass.
+
+### Findings
+- [x] (must-fix) store_import.cpp was in the core cube_bathymetry library, so cube_bathymetry_node/detections_to_pointcloud transitively linked the store — moved to a dedicated cube_bathymetry_store_import target; verified node no longer links the store — `CMakeLists.txt`
+- [x] (suggestion) rosbag2_cpp used but undeclared in package.xml (pre-existing via bag_to_geotiff) — added — `package.xml`
+- [x] (suggestion) nlohmann_json store-export gap forcing a cube-side workaround — filed unh_marine_autonomy#203 to fix the store export; workaround kept until then

--- a/cube_bathymetry/CMakeLists.txt
+++ b/cube_bathymetry/CMakeLists.txt
@@ -189,6 +189,9 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_detections_projector test/test_detections_projector.cpp)
   target_link_libraries(test_detections_projector cube_bathymetry)
+
+  ament_add_gtest(test_store_import test/test_store_import.cpp)
+  target_link_libraries(test_store_import cube_bathymetry)
 endif()
 
 ament_export_dependencies(rclcpp)

--- a/cube_bathymetry/CMakeLists.txt
+++ b/cube_bathymetry/CMakeLists.txt
@@ -44,7 +44,6 @@ add_library(cube_bathymetry
   src/map_sheet.cpp
   src/node.cpp
   src/parameters.cpp
-  src/store_import.cpp
 )
 
 target_include_directories(cube_bathymetry PUBLIC
@@ -55,8 +54,6 @@ target_include_directories(cube_bathymetry PUBLIC
 target_link_libraries(cube_bathymetry
   ${marine_acoustic_msgs_TARGETS}
   marine_autonomy::marine_autonomy
-  # GeoGrid -> store-tile conversion (store_import.cpp, #57).
-  marine_bathymetry_store::marine_bathymetry_store
   # DetectionsProjector needs tf2::BufferCore::lookupTransform + tf2::getEulerYPR
   # (tf2::tf2, the minimal core target -- no rclcpp in its own interface) and
   # tf2::fromMsg(Quaternion) used by getEulerYPR (tf2_geometry_msgs, header-only).
@@ -78,6 +75,22 @@ install(TARGETS cube_bathymetry EXPORT export_${PROJECT_NAME}
 )
 
 install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
+
+# GeoGrid -> bathymetry-store-tile conversion (#57). Kept in its OWN target so the
+# store dependency does NOT leak into the core cube_bathymetry library, and thus
+# not into the live runtime nodes (cube_bathymetry_node, detections_to_pointcloud)
+# which have no need for the offline data store. Only the offline import_bag tool
+# and its test link this.
+add_library(cube_bathymetry_store_import src/store_import.cpp)
+target_link_libraries(cube_bathymetry_store_import
+  cube_bathymetry
+  marine_bathymetry_store::marine_bathymetry_store
+)
+install(TARGETS cube_bathymetry_store_import EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
 
 
 add_executable(cube_bathymetry_node src/cube_bathymetry_node.cpp)
@@ -142,10 +155,9 @@ install(TARGETS bag_to_geotiff
 add_executable(import_bag src/import_bag_main.cpp)
 
 target_link_libraries(import_bag
-  cube_bathymetry
+  cube_bathymetry_store_import   # brings in cube_bathymetry + marine_bathymetry_store
   ${geometry_msgs_TARGETS}
   ${marine_acoustic_msgs_TARGETS}
-  marine_bathymetry_store::marine_bathymetry_store
   rclcpp::rclcpp
   rosbag2_cpp::rosbag2_cpp
   rosbag2_transport::rosbag2_transport
@@ -191,7 +203,7 @@ if(BUILD_TESTING)
   target_link_libraries(test_detections_projector cube_bathymetry)
 
   ament_add_gtest(test_store_import test/test_store_import.cpp)
-  target_link_libraries(test_store_import cube_bathymetry)
+  target_link_libraries(test_store_import cube_bathymetry_store_import)
 endif()
 
 ament_export_dependencies(rclcpp)

--- a/cube_bathymetry/CMakeLists.txt
+++ b/cube_bathymetry/CMakeLists.txt
@@ -15,6 +15,11 @@ find_package(lifecycle_msgs)
 find_package(marine_acoustic_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)  # odometry for speed-over-ground
 find_package(marine_autonomy REQUIRED)
+# marine_bathymetry_store's exported link interface references
+# nlohmann_json::nlohmann_json (its registry JSON I/O) but does not export the
+# dependency, so the IMPORTED target must be resolved here before consuming it.
+find_package(nlohmann_json REQUIRED)
+find_package(marine_bathymetry_store REQUIRED)  # store epoch import (#57)
 find_package(geodesy REQUIRED)  # WGS84 Vincenty inverse (geo_grid distance)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
@@ -39,6 +44,7 @@ add_library(cube_bathymetry
   src/map_sheet.cpp
   src/node.cpp
   src/parameters.cpp
+  src/store_import.cpp
 )
 
 target_include_directories(cube_bathymetry PUBLIC
@@ -49,6 +55,8 @@ target_include_directories(cube_bathymetry PUBLIC
 target_link_libraries(cube_bathymetry
   ${marine_acoustic_msgs_TARGETS}
   marine_autonomy::marine_autonomy
+  # GeoGrid -> store-tile conversion (store_import.cpp, #57).
+  marine_bathymetry_store::marine_bathymetry_store
   # DetectionsProjector needs tf2::BufferCore::lookupTransform + tf2::getEulerYPR
   # (tf2::tf2, the minimal core target -- no rclcpp in its own interface) and
   # tf2::fromMsg(Quaternion) used by getEulerYPR (tf2_geometry_msgs, header-only).
@@ -127,6 +135,25 @@ target_link_libraries(bag_to_geotiff
 )
 
 install(TARGETS bag_to_geotiff
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+# Offline detections-bag -> CUBE GeoMapSheet -> bathymetry-store epoch importer (#57).
+add_executable(import_bag src/import_bag_main.cpp)
+
+target_link_libraries(import_bag
+  cube_bathymetry
+  ${geometry_msgs_TARGETS}
+  ${marine_acoustic_msgs_TARGETS}
+  marine_bathymetry_store::marine_bathymetry_store
+  rclcpp::rclcpp
+  rosbag2_cpp::rosbag2_cpp
+  rosbag2_transport::rosbag2_transport
+  tf2_geometry_msgs::tf2_geometry_msgs
+  tf2_ros::tf2_ros
+)
+
+install(TARGETS import_bag
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/cube_bathymetry/include/cube_bathymetry/store_import.h
+++ b/cube_bathymetry/include/cube_bathymetry/store_import.h
@@ -1,0 +1,81 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+
+#ifndef CUBE_BATHYMETRY__STORE_IMPORT_H_
+#define CUBE_BATHYMETRY__STORE_IMPORT_H_
+
+#include <cstdint>
+#include <map>
+
+#include "cube_bathymetry/geo_grid.h"
+#include "cube_bathymetry/geo_map_sheet.h"
+#include "marine_autonomy/gggs.h"
+#include "marine_bathymetry_store/bathymetry_tile.hpp"
+
+namespace cube
+{
+
+/// @brief Convert one CUBE @ref GeoGrid into a marine_bathymetry_store tile.
+///
+/// `GeoGrid::values()` is a flat, positional `vector<DepthAndUncertainty>` in
+/// `gggs::CellAreaIterator` order over `grid.index()` (row 0 = south, column 0 =
+/// west, row-major; NaN-filled where no estimate exists). `BathymetryTile::set`
+/// uses the **same** GGGS cell order (`TiledRasterTile::offset(row,col)` is
+/// row-major, row 0 = south), so we walk a second `CellAreaIterator` over the
+/// same index in lockstep with `values()` and read `(*it).row()/.column()` to
+/// recover each value's destination cell. Only **finite-depth** cells are
+/// written; NaN cells are skipped (the tile defaults to NaN no-data).
+///
+/// `values()` returns `float`; the store cell is `double`, so each field is
+/// widened. `values()` mutates node state (it flushes the median pre-filter), so
+/// it is called exactly **once** per grid here.
+///
+/// @param grid          The CUBE grid to convert.
+/// @param timestamp_ns  Acquisition/import time written into every finite cell
+///                      (nanoseconds since the Unix epoch). A single value per
+///                      import keeps the result deterministic.
+/// @param source_index  Registry source index written into every finite cell.
+/// @return A `BathymetryTile` for `grid.index()` holding the finite cells.
+  marine_bathymetry_store::BathymetryTile geoGridToTile(
+    const GeoGrid & grid, int64_t timestamp_ns, uint16_t source_index);
+
+/// @brief Convert every grid of a @ref GeoMapSheet into a per-grid tile map.
+///
+/// Iterates `map_sheet.grids()` and converts each through @ref geoGridToTile.
+/// A grid that produces **no** finite cells is omitted (an empty tile would
+/// just persist as an all-no-data file). The result is keyed by
+/// `gggs::GridIndex` and is suitable to pass straight to
+/// `marine_bathymetry_store::BathymetryStore::importEpoch`.
+///
+/// Deterministic for a fixed map sheet: `grids()` returns grids in
+/// `gggs::GridIndex` map order, and each grid converts deterministically.
+///
+/// @param map_sheet     The CUBE map sheet to convert.
+/// @param timestamp_ns  Acquisition/import time for every finite cell.
+/// @param source_index  Registry source index for every finite cell.
+  std::map < gggs::GridIndex, marine_bathymetry_store::BathymetryTile >
+  mapSheetToEpochTiles(
+    const GeoMapSheet & map_sheet, int64_t timestamp_ns, uint16_t source_index);
+
+}  // namespace cube
+
+#endif  // CUBE_BATHYMETRY__STORE_IMPORT_H_

--- a/cube_bathymetry/package.xml
+++ b/cube_bathymetry/package.xml
@@ -16,6 +16,8 @@
   <depend>marine_acoustic_msgs</depend>
   <depend>nav_msgs</depend>  <!-- odometry for speed-over-ground -->
   <depend>marine_autonomy</depend>
+  <depend>marine_bathymetry_store</depend>  <!-- store epoch import (#57) -->
+  <depend>nlohmann-json-dev</depend>  <!-- store's unexported link-interface dep (#57) -->
   <depend>geodesy</depend>
   <depend>rclcpp</depend>
   <depend>rosbag2_transport</depend>

--- a/cube_bathymetry/package.xml
+++ b/cube_bathymetry/package.xml
@@ -20,6 +20,7 @@
   <depend>nlohmann-json-dev</depend>  <!-- store's unexported link-interface dep (#57) -->
   <depend>geodesy</depend>
   <depend>rclcpp</depend>
+  <depend>rosbag2_cpp</depend>  <!-- bag readers in import_bag / bag_to_geotiff -->
   <depend>rosbag2_transport</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>sensor_msgs</depend>

--- a/cube_bathymetry/src/import_bag_main.cpp
+++ b/cube_bathymetry/src/import_bag_main.cpp
@@ -1,0 +1,518 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// import_bag: offline detections-bag -> CUBE GeoMapSheet -> bathymetry-store
+// epoch importer (PR-B of unh_marine_autonomy#147, cube_bathymetry#57).
+//
+// Mirrors the bag_to_geotiff `-d` offline-projection chain (rosbag2
+// SequentialReader -> tf2::BufferCore from /tf + /tf_static -> DetectionsProjector
+// -> per-sounding lookupTransform("earth", frame_id, stamp) -> GeoSounding ->
+// GeoMapSheet) but writes a marine_bathymetry_store epoch instead of a GeoTIFF.
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "cube_bathymetry/detections_projector.h"
+#include "cube_bathymetry/geo_map_sheet.h"
+#include "cube_bathymetry/geo_sounding.h"
+#include "cube_bathymetry/store_import.h"
+#include "geometry_msgs/msg/point_stamped.hpp"
+#include "marine_acoustic_msgs/msg/sonar_detections.hpp"
+#include "marine_autonomy/gz4d_geo.h"
+#include "marine_bathymetry_store/bathymetry_store.hpp"
+#include "marine_bathymetry_store/epoch.hpp"
+#include "marine_bathymetry_store/registry.hpp"
+#include "marine_bathymetry_store/tile_io.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rosbag2_transport/reader_writer_factory.hpp"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "tf2_msgs/msg/tf_message.hpp"
+#include "tf2_ros/buffer.h"
+
+void usage()
+{
+  std::cout << "usage: import_bag [options] -o <store_dir> -e <epoch> "
+    "-d <detections_topic> <bag> [<bag> ...]\n";
+  std::cout << "  -o <store_dir>: Output bathymetry-store directory (created if "
+    "needed)\n";
+  std::cout << "  -e <epoch>: Epoch label (ISO-8601 acquisition date, e.g. "
+    "2026-06-15)\n";
+  std::cout << "  -d <detections_topic>: marine_acoustic_msgs/SonarDetections "
+    "topic to replay through CUBE (required)\n";
+  std::cout << "  -r <meters>: Grid resolution (nominal; snapped to GGGS). "
+    "Default 1.0\n";
+  std::cout << "  --iho-order <order>: CUBE IHO order (default order1a)\n";
+  std::cout << "  -l <count>: Stop after this many pings (debugging)\n";
+  std::cout << "  --source-id <id>: Registry source id recorded for every cell "
+    "(default cube-replay)\n";
+  std::cout << "  --platform / --sensor / --sensor-class / --campaign <str>: "
+    "registry provenance fields\n";
+  std::cout << "  Frame/range overrides for the offline projector (must match "
+    "the bag's namespaced frames, or the grid comes out empty):\n";
+  std::cout << "    --base-link-frame, --level-frame, --tide-frame\n";
+  std::cout << "    --minimum-range, --maximum-range (meters)\n";
+  exit(-1);
+}
+
+bool bag_filter(const std::string & type)
+{
+  return type == "tf2_msgs/msg/TFMessage" ||
+         type == "marine_acoustic_msgs/msg/SonarDetections";
+}
+
+bool ends_with(const std::string & str, const std::string & suffix)
+{
+  if (str.length() >= suffix.length()) {
+    return 0 == str.compare(str.length() - suffix.length(), suffix.length(), suffix);
+  }
+  return false;
+}
+
+/// Keep track of multiple bag files and retrieve messages in chronological order.
+/// (Mirrors bag_to_geotiff's BagReaders.)
+class BagReaders
+{
+public:
+  /// A bag serialized message with the data type.
+  struct Message
+  {
+    std::string data_type;
+    rosbag2_storage::SerializedBagMessageSharedPtr message;
+
+    using ConstPtr = std::shared_ptr<const Message>;
+
+    Message(
+      rosbag2_storage::SerializedBagMessageSharedPtr message,
+      const rosbag2_cpp::Reader & reader)
+    : message(message)
+    {
+      for (auto & topic_info : reader.get_all_topics_and_types()) {
+        if (topic_info.name == message->topic_name) {
+          data_type = topic_info.type;
+          break;
+        }
+      }
+    }
+  };
+
+  explicit BagReaders(const std::vector<std::string> & bagfile_names)
+  {
+    for (const auto & bagfile_name : bagfile_names) {
+      readers_[bagfile_name].open(bagfile_name);
+    }
+  }
+
+  auto start_time()
+  {
+    auto start_time = readers_.begin()->second.reader->get_metadata().starting_time;
+    for (auto & reader : readers_) {
+      if (reader.second.reader->get_metadata().starting_time < start_time) {
+        start_time = reader.second.reader->get_metadata().starting_time;
+      }
+    }
+    return start_time;
+  }
+
+  auto end_time()
+  {
+    auto end_time = readers_.begin()->second.reader->get_metadata().starting_time +
+      readers_.begin()->second.reader->get_metadata().duration;
+    for (auto & reader : readers_) {
+      if (reader.second.reader->get_metadata().starting_time +
+        reader.second.reader->get_metadata().duration > end_time)
+      {
+        end_time = reader.second.reader->get_metadata().starting_time +
+          reader.second.reader->get_metadata().duration;
+      }
+    }
+    return end_time;
+  }
+
+  Message::ConstPtr next()
+  {
+    Bag * has_next = nullptr;
+    for (auto & reader : readers_) {
+      if (reader.second.has_next()) {
+        if (!has_next ||
+          reader.second.peek_next()->message->send_timestamp <
+          has_next->peek_next()->message->send_timestamp)
+        {
+          has_next = &reader.second;
+        }
+      }
+    }
+    if (has_next) {
+      return has_next->pop_next();
+    }
+    return {};
+  }
+
+private:
+  struct Bag
+  {
+    std::unique_ptr<rosbag2_cpp::Reader> reader;
+    Message::ConstPtr next_message;
+
+    void open(const std::string & file_name)
+    {
+      rosbag2_storage::StorageOptions storage_options;
+      storage_options.uri = file_name;
+      reader = rosbag2_transport::ReaderWriterFactory::make_reader(storage_options);
+      reader->open(storage_options);
+      if (reader->has_next()) {
+        next_message = std::make_shared<Message>(reader->read_next(), *reader);
+      }
+    }
+
+    bool has_next()
+    {
+      return static_cast<bool>(next_message);
+    }
+
+    Message::ConstPtr peek_next()
+    {
+      return next_message;
+    }
+
+    Message::ConstPtr pop_next()
+    {
+      auto return_value = next_message;
+      if (reader->has_next()) {
+        next_message = std::make_shared<Message>(reader->read_next(), *reader);
+      } else {
+        next_message.reset();
+      }
+      return return_value;
+    }
+  };
+
+  std::map<std::string, Bag> readers_;
+};
+
+
+int main(int argc, char * argv[])
+{
+  std::vector<std::string> arguments(argv + 1, argv + argc);
+  if (arguments.empty()) {
+    usage();
+  }
+
+  std::vector<std::string> bagfile_names;
+  std::string store_dir;
+  std::string epoch_label;
+  std::string detections_topic;  // required
+  double resolution = 1.0;
+  std::string iho_order = "order1a";
+  int ping_count_limit = 0;
+
+  // Registry provenance fields for the imported cells.
+  marine_bathymetry_store::SourceRecord source_record;
+  source_record.source_id = "cube-replay";
+
+  // DetectionsProjector configuration for the offline path. Defaults match
+  // detections_to_pointcloud's node defaults so a detections-only bag projects
+  // the same way the live node would.
+  cube::ProjectorParams projector_params;
+
+  for (auto arg = arguments.begin(); arg != arguments.end(); arg++) {
+    if (*arg == "-h") {
+      usage();
+    } else if (*arg == "-o") {
+      arg++;
+      store_dir = *arg;
+    } else if (*arg == "-e") {
+      arg++;
+      epoch_label = *arg;
+    } else if (*arg == "-d") {
+      arg++;
+      detections_topic = *arg;
+    } else if (*arg == "-r") {
+      arg++;
+      resolution = std::stod(*arg);
+    } else if (*arg == "--iho-order") {
+      arg++;
+      iho_order = *arg;
+    } else if (*arg == "-l") {
+      arg++;
+      ping_count_limit = std::stoi(*arg);
+    } else if (*arg == "--source-id") {
+      arg++;
+      source_record.source_id = *arg;
+    } else if (*arg == "--platform") {
+      arg++;
+      source_record.platform = *arg;
+    } else if (*arg == "--sensor") {
+      arg++;
+      source_record.sensor = *arg;
+    } else if (*arg == "--sensor-class") {
+      arg++;
+      source_record.sensor_class = *arg;
+    } else if (*arg == "--campaign") {
+      arg++;
+      source_record.campaign = *arg;
+    } else if (*arg == "--base-link-frame") {
+      arg++;
+      projector_params.base_link_frame = *arg;
+    } else if (*arg == "--level-frame") {
+      arg++;
+      projector_params.level_frame = *arg;
+    } else if (*arg == "--tide-frame") {
+      arg++;
+      projector_params.tide_frame = *arg;
+    } else if (*arg == "--minimum-range") {
+      arg++;
+      projector_params.minimum_range = std::stod(*arg);
+    } else if (*arg == "--maximum-range") {
+      arg++;
+      projector_params.maximum_range = std::stod(*arg);
+    } else {
+      bagfile_names.push_back(*arg);
+    }
+  }
+
+  if (store_dir.empty() || epoch_label.empty() || detections_topic.empty() ||
+    bagfile_names.empty())
+  {
+    std::cerr << "error: -o <store_dir>, -e <epoch>, -d <detections_topic>, and "
+      "at least one bag are all required\n";
+    usage();
+  }
+
+  // Fail fast on a bad epoch label before doing any (potentially long) replay.
+  try {
+    marine_bathymetry_store::validateEpochLabel(epoch_label);
+  } catch (const std::exception & e) {
+    std::cerr << "error: invalid epoch label '" << epoch_label << "': " << e.what()
+              << std::endl;
+    return 1;
+  }
+
+  std::cout << "Detections topic: " << detections_topic
+            << " (offline projection, vessel_speed = NaN)" << std::endl;
+  std::cout << "Store dir: " << store_dir << "  Epoch: " << epoch_label << std::endl;
+
+  cube::DetectionsProjector projector(projector_params);
+
+  // Accumulated offline-projection diagnostics, surfaced at the end so a
+  // misconfigured-frames or over-tight-range run is diagnosable rather than a
+  // silently sparse/empty epoch (the failure mode #43 exists to kill).
+  size_t proj_pings = 0;
+  size_t proj_soundings = 0;
+  size_t proj_filtered_range = 0;
+  size_t proj_missing_attitude = 0;
+  size_t proj_missing_heave = 0;
+
+  BagReaders bag_readers(bagfile_names);
+
+  std::cout << "calculating total time..." << std::endl;
+  auto begin_time = bag_readers.start_time();
+  auto end_time = bag_readers.end_time();
+  auto total_duration = end_time - begin_time;
+
+  auto start_time_t = std::chrono::system_clock::to_time_t(begin_time);
+  std::cout << "start time: "
+            << std::put_time(std::gmtime(&start_time_t), "%Y-%m-%d %H:%M:%S") << std::endl;
+  auto end_time_t = std::chrono::system_clock::to_time_t(end_time);
+  std::cout << "end time: "
+            << std::put_time(std::gmtime(&end_time_t), "%Y-%m-%d %H:%M:%S") << std::endl;
+  std::cout << "total time: "
+            << std::chrono::duration_cast<std::chrono::seconds>(total_duration).count()
+            << " seconds" << std::endl;
+
+  // Single, deterministic per-cell timestamp: the bag's nominal start time in ns
+  // since the Unix epoch. A single value per import keeps the epoch deterministic
+  // (every replay of the same bag yields the same cell stamps).
+  const int64_t cell_timestamp_ns =
+    std::chrono::duration_cast<std::chrono::nanoseconds>(
+    begin_time.time_since_epoch()).count();
+
+  auto clock = std::make_shared<rclcpp::Clock>();
+  tf2_ros::Buffer tfBuffer(clock, total_duration);
+
+  cube::GeoMapSheet geo_map_sheet(resolution, iho_order);
+  std::cout << "requested resolution: " << resolution << " nominal used: "
+            << geo_map_sheet.nominalCellSizeMeters() << std::endl;
+
+  std::cout << "reading messages..." << std::endl;
+
+  int ping_count = 0;
+  uint64_t msg_count = 0;
+  auto last_report_time = std::chrono::system_clock::now();
+  std::chrono::seconds report_interval(1);
+
+  for (auto message = bag_readers.next(); message; message = bag_readers.next()) {
+    if (!bag_filter(message->data_type)) {
+      continue;
+    }
+    ++msg_count;
+
+    if (message->data_type == "tf2_msgs/msg/TFMessage") {
+      if (ends_with(message->message->topic_name, "/tf_static")) {
+        rclcpp::SerializedMessage serialized_message(*message->message->serialized_data);
+        tf2_msgs::msg::TFMessage tf_message;
+        rclcpp::Serialization<tf2_msgs::msg::TFMessage>().deserialize_message(
+          &serialized_message, &tf_message);
+        for (const auto & t : tf_message.transforms) {
+          tfBuffer.setTransform(t, "", true);
+        }
+      }
+      if (ends_with(message->message->topic_name, "/tf")) {
+        try {
+          rclcpp::SerializedMessage serialized_message(*message->message->serialized_data);
+          tf2_msgs::msg::TFMessage tf_message;
+          rclcpp::Serialization<tf2_msgs::msg::TFMessage>().deserialize_message(
+            &serialized_message, &tf_message);
+          for (const auto & t : tf_message.transforms) {
+            tfBuffer.setTransform(t, "", false);
+          }
+          auto now = std::chrono::system_clock::now();
+          if (now >= last_report_time + report_interval && !tf_message.transforms.empty() &&
+            total_duration.count() > 0)
+          {
+            double progress =
+              (tf2_ros::fromMsg(tf_message.transforms.front().header.stamp) - begin_time)
+              .count() / static_cast<double>(total_duration.count());
+            std::cout << "\r" << static_cast<int>(100 * progress) << "%\t" << msg_count
+                      << " messages, " << ping_count << " pings            ";
+            std::cout.flush();
+            last_report_time = now;
+          }
+        } catch (const std::exception & e) {
+          std::cerr << e.what() << '\n';
+        }
+      }
+    }
+
+    if (message->data_type == "marine_acoustic_msgs/msg/SonarDetections" &&
+      message->message->topic_name == detections_topic)
+    {
+      try {
+        rclcpp::SerializedMessage serialized_message(*message->message->serialized_data);
+        marine_acoustic_msgs::msg::SonarDetections detections;
+        rclcpp::Serialization<marine_acoustic_msgs::msg::SonarDetections>()
+        .deserialize_message(&serialized_message, &detections);
+
+        auto projection = projector.project(detections, tfBuffer, std::nanf(""));
+        ++proj_pings;
+        proj_soundings += projection.soundings.size();
+        proj_filtered_range += projection.diagnostics.filtered_range;
+        proj_missing_attitude += projection.diagnostics.missing_attitude;
+        proj_missing_heave += projection.diagnostics.missing_heave;
+
+        // Georeference each sonar-frame sounding to lat/lon via the bag's TF
+        // buffer at the ping stamp, exactly as bag_to_geotiff -d does.
+        try {
+          auto transform = tfBuffer.lookupTransform(
+            "earth", detections.header.frame_id, detections.header.stamp);
+
+          std::vector<cube::GeoSounding> soundings;
+          soundings.reserve(projection.soundings.size());
+          for (const auto & s : projection.soundings) {
+            geometry_msgs::msg::PointStamped sounding_re_sensor;
+            sounding_re_sensor.point.x = s.sonar_relative_position.x;
+            sounding_re_sensor.point.y = s.sonar_relative_position.y;
+            sounding_re_sensor.point.z = s.sonar_relative_position.z;
+            sounding_re_sensor.header = detections.header;
+
+            geometry_msgs::msg::PointStamped sounding_ecef;
+            tf2::doTransform(sounding_re_sensor, sounding_ecef, transform);
+
+            gz4d::GeoPointECEF ecef(
+              sounding_ecef.point.x, sounding_ecef.point.y, sounding_ecef.point.z);
+            gz4d::GeoPointLatLongDegrees ll(ecef);
+            cube::GeoSounding gs(ll);
+            gs.sounding.vertical_error = s.vertical_error;
+            gs.sounding.horizontal_error = s.horizontal_error;
+            soundings.push_back(gs);
+          }
+          geo_map_sheet.addSoundings(soundings);
+          ping_count++;
+        } catch (const tf2::TransformException & e) {
+          // No earth transform at this stamp yet -- drop the ping (the bag may
+          // start before the first map->earth fix); matches bag_to_geotiff.
+          std::cerr << "Transform Exception: " << e.what() << std::endl;
+        }
+      } catch (const std::exception & e) {
+        std::cerr << e.what() << '\n';
+      }
+    }
+
+    if (ping_count_limit > 0 && ping_count >= ping_count_limit) {
+      std::cout << "\nPing count limit of " << ping_count_limit << " reached" << std::endl;
+      break;
+    }
+  }
+
+  std::cout << "\ndone." << std::endl;
+  std::cout << "Offline projection: " << proj_pings << " pings, " << proj_soundings
+            << " soundings (" << proj_filtered_range << " range-filtered, "
+            << proj_missing_attitude << " missing attitude, " << proj_missing_heave
+            << " missing heave)" << std::endl;
+  if (proj_pings > 0 && proj_soundings == 0) {
+    std::cerr << "WARNING: projected 0 soundings from " << proj_pings
+              << " pings -- check the --*-frame overrides match the bag's "
+              << "namespaced frames (see README 'Configuring frames per platform')."
+              << std::endl;
+  }
+
+  std::cout << "Building store epoch..." << std::endl;
+
+  // The GeoMapSheet picks a GGGS level from the requested cell size; build the
+  // store at the matching default level. importEpoch is multi-level, so the
+  // GridIndex on each tile carries the authoritative level regardless.
+  marine_bathymetry_store::BathymetryStore store =
+    marine_bathymetry_store::BathymetryStore::fromCellSize(
+    static_cast<float>(geo_map_sheet.nominalCellSizeMeters()));
+
+  marine_bathymetry_store::SourceRegistry registry;
+  const uint16_t source_index = registry.registerSource(source_record);
+
+  auto tiles = cube::mapSheetToEpochTiles(geo_map_sheet, cell_timestamp_ns, source_index);
+  std::cout << "Tiles with data: " << tiles.size() << std::endl;
+
+  if (tiles.empty()) {
+    std::cerr << "WARNING: no tiles had finite data -- nothing imported. Check "
+      "the projector frame overrides and the detections topic." << std::endl;
+  }
+
+  // Draft layer + Replayed provenance: this is a full-bag CUBE replay, the
+  // authoritative end-of-day compaction product (ADR-0002 A1.2).
+  store.importEpoch(
+    marine_bathymetry_store::SourceLayer::Draft, epoch_label, std::move(tiles),
+    marine_bathymetry_store::Provenance::Replayed);
+
+  std::size_t written = marine_bathymetry_store::save(store, store_dir, &registry);
+  std::cout << "Saved " << written << " tiles to " << store_dir << " (epoch "
+            << epoch_label << ")." << std::endl;
+
+  std::cout << "done!" << std::endl;
+  return 0;
+}

--- a/cube_bathymetry/src/store_import.cpp
+++ b/cube_bathymetry/src/store_import.cpp
@@ -1,0 +1,89 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+
+#include "cube_bathymetry/store_import.h"
+
+#include <cmath>
+#include <utility>
+#include <vector>
+
+#include "cube_bathymetry/common.h"
+
+namespace cube
+{
+
+marine_bathymetry_store::BathymetryTile geoGridToTile(
+  const GeoGrid & grid, int64_t timestamp_ns, uint16_t source_index)
+{
+  marine_bathymetry_store::BathymetryTile tile(grid.index());
+
+  // values() mutates node state (flushes the median pre-filter) -- call once and
+  // cache. It is positional in CellAreaIterator order over grid.index().
+  const std::vector<DepthAndUncertainty> values = grid.values();
+
+  // Walk the SAME iterator the same way values() does, so values[k] belongs to
+  // the cell visited on the k-th iteration. CellAreaIterator(grid) covers the
+  // full 960x960 grid row-major (row 0 = south, column 0 = west) -- exactly the
+  // layout BathymetryTile::set(row, col, ...) expects.
+  gggs::CellAreaIterator it(grid.index());
+  std::size_t k = 0;
+  for (; it.valid() && k < values.size(); it.next(), ++k) {
+    const DepthAndUncertainty & v = values[k];
+    if (std::isnan(v.depth)) {
+      continue;  // no estimate here; leave the tile's NaN no-data sentinel
+    }
+    tile.set(
+      (*it).row(), (*it).column(),
+      marine_bathymetry_store::BathyCell{
+        static_cast<double>(v.depth),
+        static_cast<double>(v.uncertainty),
+        timestamp_ns,
+        source_index});
+  }
+
+  return tile;
+}
+
+std::map<gggs::GridIndex, marine_bathymetry_store::BathymetryTile>
+mapSheetToEpochTiles(
+  const GeoMapSheet & map_sheet, int64_t timestamp_ns, uint16_t source_index)
+{
+  std::map<gggs::GridIndex, marine_bathymetry_store::BathymetryTile> tiles;
+
+  for (const auto & grid : map_sheet.grids()) {
+    if (!grid) {
+      continue;
+    }
+    marine_bathymetry_store::BathymetryTile tile =
+      geoGridToTile(*grid, timestamp_ns, source_index);
+    // Drop a grid that yielded no finite cells -- an all-no-data tile would just
+    // persist as an empty file.
+    if (!tile.dirty()) {
+      continue;
+    }
+    tiles.emplace(grid->index(), std::move(tile));
+  }
+
+  return tiles;
+}
+
+}  // namespace cube

--- a/cube_bathymetry/test/test_store_import.cpp
+++ b/cube_bathymetry/test/test_store_import.cpp
@@ -1,0 +1,157 @@
+// Copyright 2026 Center for Coastal and Ocean Mapping & NOAA-UNH Joint
+// Hydrographic Center, University of New Hampshire
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstdint>
+#include <map>
+#include <vector>
+
+#include "cube_bathymetry/common.h"
+#include "cube_bathymetry/geo_map_sheet.h"
+#include "cube_bathymetry/geo_sounding.h"
+#include "cube_bathymetry/store_import.h"
+#include "marine_autonomy/gggs.h"
+#include "marine_bathymetry_store/bathy_cell.hpp"
+#include "marine_bathymetry_store/bathymetry_tile.hpp"
+
+namespace cube
+{
+
+namespace
+{
+// A handful of synthetic soundings near a single point so they all land in one
+// GGGS grid (kept tiny so the test is fast and deterministic).
+std::vector<GeoSounding> makeSoundings()
+{
+  std::vector<GeoSounding> soundings;
+  const double base_lat = 43.07;
+  const double base_lon = -70.76;
+  for (int i = 0; i < 5; ++i) {
+    // Small lat/lon offsets (~ a few metres) so they spread across a few cells.
+    gz4d::GeoPointLatLongDegrees point(
+      base_lat + i * 1e-5, base_lon + i * 1e-5, -10.0 - i);
+    GeoSounding s(point);
+    s.sounding.vertical_error = 0.5f;
+    s.sounding.horizontal_error = 0.1f;
+    soundings.push_back(s);
+  }
+  return soundings;
+}
+
+constexpr int64_t kStamp = 1234567890123456789LL;
+constexpr uint16_t kSource = 7;
+}  // namespace
+
+// The produced tile cells must match the grid's finite values cell-for-cell, in
+// depth and uncertainty, and only finite-depth cells must be written.
+TEST(StoreImport, TileCellsMatchGridValues)
+{
+  GeoMapSheet ms(1.0f);
+  ms.addSoundings(makeSoundings());
+
+  auto grids = ms.grids();
+  ASSERT_FALSE(grids.empty());
+
+  std::size_t finite_total = 0;
+  for (const auto & grid : grids) {
+    ASSERT_TRUE(static_cast<bool>(grid));
+
+    // Cache values() once (it mutates node state) and re-derive the cell mapping
+    // the same way geoGridToTile does, then compare against the produced tile.
+    const std::vector<DepthAndUncertainty> values = grid->values();
+    const marine_bathymetry_store::BathymetryTile tile =
+      geoGridToTile(*grid, kStamp, kSource);
+
+    gggs::CellAreaIterator it(grid->index());
+    std::size_t k = 0;
+    std::size_t finite_in_grid = 0;
+    for (; it.valid() && k < values.size(); it.next(), ++k) {
+      const marine_bathymetry_store::BathyCell cell =
+        tile.get((*it).row(), (*it).column());
+      if (std::isnan(values[k].depth)) {
+        // Skipped cell -- the tile keeps its NaN no-data sentinel.
+        EXPECT_FALSE(cell.hasData());
+      } else {
+        ++finite_in_grid;
+        ASSERT_TRUE(cell.hasData());
+        EXPECT_DOUBLE_EQ(cell.depth, static_cast<double>(values[k].depth));
+        EXPECT_DOUBLE_EQ(cell.uncertainty, static_cast<double>(values[k].uncertainty));
+        EXPECT_EQ(cell.timestamp, kStamp);
+        EXPECT_EQ(cell.source_index, kSource);
+      }
+    }
+    finite_total += finite_in_grid;
+  }
+  EXPECT_GT(finite_total, 0u) << "synthetic soundings should populate some cells";
+}
+
+// Converting the same map sheet twice must yield an identical tile set: same
+// grids, and byte-identical depth/uncertainty/timestamp/source bands.
+TEST(StoreImport, ConversionIsDeterministic)
+{
+  GeoMapSheet ms(1.0f);
+  ms.addSoundings(makeSoundings());
+
+  auto tiles_a = mapSheetToEpochTiles(ms, kStamp, kSource);
+  auto tiles_b = mapSheetToEpochTiles(ms, kStamp, kSource);
+
+  ASSERT_FALSE(tiles_a.empty());
+  ASSERT_EQ(tiles_a.size(), tiles_b.size());
+
+  auto it_a = tiles_a.begin();
+  auto it_b = tiles_b.begin();
+  for (; it_a != tiles_a.end(); ++it_a, ++it_b) {
+    EXPECT_EQ(it_a->first, it_b->first);  // same GridIndex key
+
+    const auto & ta = it_a->second;
+    const auto & tb = it_b->second;
+
+    // depthBand() returns NaN for no-data cells, so compare with a NaN-aware
+    // predicate (NaN != NaN under ==).
+    const auto & da = ta.depthBand();
+    const auto & db = tb.depthBand();
+    const auto & ua = ta.uncertaintyBand();
+    const auto & ub = tb.uncertaintyBand();
+    ASSERT_EQ(da.size(), db.size());
+    for (std::size_t i = 0; i < da.size(); ++i) {
+      if (std::isnan(da[i])) {
+        EXPECT_TRUE(std::isnan(db[i]));
+      } else {
+        EXPECT_DOUBLE_EQ(da[i], db[i]);
+        EXPECT_DOUBLE_EQ(ua[i], ub[i]);
+      }
+    }
+    EXPECT_EQ(ta.timestampBand(), tb.timestampBand());
+    EXPECT_EQ(ta.sourceBand(), tb.sourceBand());
+  }
+}
+
+// A map sheet with no soundings produces no tiles (no empty all-no-data files).
+TEST(StoreImport, EmptyMapSheetYieldsNoTiles)
+{
+  GeoMapSheet ms(1.0f);
+  auto tiles = mapSheetToEpochTiles(ms, kStamp, kSource);
+  EXPECT_TRUE(tiles.empty());
+}
+
+}  // namespace cube


### PR DESCRIPTION
## Summary

`import_bag` — a cube-side offline tool that replays a **detections** bag through
CUBE and imports the gridded surface into `marine_bathymetry_store` as a per-day
epoch. The deterministic, full-CPU-speed store-ingestion path enabled by the
node-free `DetectionsProjector` (#43). **PR-B** of the bathymetric-store Phase-2
import; PR-A (store foundation) landed in unh_marine_autonomy#201.

Part of rolker/unh_marine_autonomy#147.

## What's in it
- `import_bag` executable: SequentialReader over the detections bag → `tf2::BufferCore`
  from `/tf`+`/tf_static` → `DetectionsProjector::project()` → per-sounding
  `lookupTransform("earth", …)` → `GeoSounding` → `GeoMapSheet::addSoundings`; then
  each `GeoGrid` → `BathymetryTile` → `importEpoch(Draft, <ISO-date>, …, Replayed)` → `save`.
- `store_import.{h,cpp}`: the `GeoGrid → BathymetryTile` conversion, in its **own**
  `cube_bathymetry_store_import` library target so the store dependency does **not**
  leak into the core library or the runtime nodes (review must-fix).
- The conversion walks a `CellAreaIterator` in lockstep with `GeoGrid::values()`'s
  positional vector (verified same single-arg iterator/bounds/order); `values()` cached
  once (it flushes node state); NaN cells skipped; `float→double` widened.

## Tests
3 new (`test_store_import`): cell-for-cell conversion correctness, determinism (same
sheet → identical tiles, NaN-aware), and empty-sheet → no tiles. **285 tests, 0 failures.**
Deep pre-push review (two adversarial passes) approved; Lens A clean (conversion verified),
Lens B's must-fix (dependency isolation) resolved.

## Follow-ups
- unh_marine_autonomy#203 — the store doesn't export its `nlohmann_json`/GDAL deps, so
  this PR carries a small `find_package(nlohmann_json)` workaround; remove once #203 lands.

Closes #57


---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
