### PR TITLE
Re-enable CUBE slope correction in Node::insert (corrected formula; producer deferred to #59)

### DIFF
--- a/.agent/work-plans/issue-15/plan.md
+++ b/.agent/work-plans/issue-15/plan.md
@@ -1,247 +1,242 @@
-# Plan: Slope correction is disabled (commented out) in Node::insert — FULL FIX
+# Plan (v3): Slope correction is disabled (commented out) in Node::insert
 
 ## Issue
 
 https://github.com/rolker/cube_bathymetry/issues/15
 
-**This is a re-plan with expanded scope** (operator decision). The prior plan only
-re-enabled the dormant block; `review-plan` rejected it (wrong formula + runtime-inert).
-This plan fixes **both**: the correct slant-range offset analog AND the prior-surface
-prediction pipeline that makes slope correction execute end-to-end.
+**Third plan.** Two prior plans got the CUBE slope-correction algorithm wrong and were
+changes-requested. The latest `## Plan Review` (round 2) pinned the correct algorithm by
+re-reading the original source line-by-line. This v3 ports *that* algorithm, verified
+against `original_cube/` before writing (see Verification below). It **REPLACES** the v2
+plan in full.
 
-## Context
+## The corrected algorithm (re-verified against `original_cube/` source)
 
-### What the original CUBE actually does
+Slope correction projects a sounding that touches down off-node onto the node along the
+**predicted seabed surface**, not along the acoustic beam. The original needs two things,
+and the prior plans misread both:
 
-Slope correction lets a sounding that touches down off-node be projected to the node
-along the local seabed slope, instead of being treated as a vertical measurement at the
-node. Two pieces are required and both exist in the original:
-
-1. **The offset** (`cube_node.c:1846`):
+1. **The offset is a predicted-SURFACE slope delta — NOT `depth/cos(angle)`.**
+   At the offset site (`cube_node.c:1846`):
    ```c
    if (snd->range != 0.0 && node->pred_depth != p->no_data_value)
        offset = node->pred_depth - snd->range;   // queued as snd->depth + offset
    ```
-   `snd->range` is **not** a horizontal/slant distance — it is a *slant-projected
-   signed depth*: `range = depth / cos(beam_angle)` (`sounding.c:1268`), computed
-   **while `depth` is still positive** (depth is negated to negative-down only later,
-   `sounding.c:1278`). So in final convention `snd->depth` is negative-down and
-   `snd->range` is **positive**, magnitude `|depth|/cos(angle) ≥ |depth|`. At boresight
-   (`angle=0`) `range = |depth|`; off-boresight `range > |depth|`.
+   `snd->range` here is **overwritten** before insert. In `mapsheet_cube.c:2434`:
+   ```c
+   data[snd].range = cube_grid_interpolate(tile, p->cube, de, dn, data[snd].dr, &pred_var);
+   ```
+   with the comment *"fill the result into the 'range' element of the sounding [bad!
+   <smack>] for cube_node_insert() to use for slope corrections."* `cube_grid_interpolate`
+   (`cube_grid.c:2360`) bilinearly interpolates the **4 surrounding nodes' `pred_depth`**
+   (`cube_grid.c:2374-2377`) at the touchdown point `(de,dn)`. So:
+   ```
+   offset = pred_depth(node) − pred_depth(touchdown)
+   queued = snd->depth + pred_depth(node) − pred_depth(touchdown)
+   ```
+   Both terms are negative-down predicted-surface depths in the *same* convention; the
+   `depth/cos(angle)` "error-model range" (`sounding.c:1268`, computed while depth is still
+   positive and negated at `sounding.c:1280`) is a **different quantity that is overwritten
+   before the offset runs** — it is irrelevant at the offset site. No `1/cos²`, no obliquity
+   factor: it is purely a surface-slope difference between node and touchdown.
 
-2. **The prediction (`pred_depth`)** — produced two ways in the original:
-   - **External prior surface**: `cube_grid_initialise` / `cube_grid_init_unct`
-     (`cube_grid.c:1666,1773`) loop every node and call
-     `cube_node_set_preddepth(node, depth, var)` from a supplied prior bathymetry
-     array, then seed a base hypothesis via `cube_node_add_null_hypothesis`.
-   - **Self-bootstrapped from current estimates**: `cube_grid_interpolate`
-     (`cube_grid.c:2360`) does bilinear interpolation of the **4 nearest nodes'
-     current `pred_depth`** to predict depth at an arbitrary point; returns `0.0`
-     (no correction) unless all 4 corners have valid `pred_depth`.
+2. **`pred_depth` does NOT self-bootstrap from running estimates.**
+   `cube_grid_insert_depths` (`cube_grid.c:1877-1992`) iterates nodes and calls only
+   `cube_node_insert` — it has **no** `cube_grid_interpolate` and **no**
+   `cube_node_set_preddepth` call. `pred_depth` is seeded in exactly two places:
+   - **External prior**: `cube_grid_initialise` (`cube_grid.c:1665`) loops every node, calls
+     `cube_node_set_preddepth(node, depth, var)` (`:1712`) from a supplied prior bathymetry
+     array `f32 *data`, and seeds a base hypothesis via `cube_node_add_null_hypothesis`
+     (`:1730`).
+   - **Touchdown interpolation** of that prior surface, written into `snd->range`
+     (`mapsheet_cube.c:2434`, above).
+   `cube_grid_interpolate` returns `0.0` (no correction) unless **all 4 corners** have valid
+   `pred_depth` (`cube_grid.c:2379-2384`). Both prior plans invented an
+   interpolate-from-running-estimates-during-insert path. **It does not exist in the
+   original.**
 
-The convention sentinels (`cube_node.c:1078`, `cube_node_set_preddepth` doc):
-`pred_depth == NaN` ⇒ do not incorporate data; `pred_depth == INVALID` ⇒ no prediction
-available, no slope correction (offset 0). The port already mirrors these in
-`Node::insert` (`node.cpp:83,93`).
+### Verification performed for this plan (read, not assumed)
 
-### The port today
-
-- `Sounding` (`sounding.h`) has **no `range` field**. It has
-  `sonar_relative_position.z = range * cos(tx) * cos(rx)` — the **vertical component**
-  of the slant range (= `|depth|`, positive-down), which is the *wrong* analog for
-  `snd->range` (the prior plan's bug: differs by `1/cos²`, not a sign flip).
-- `predicted_depth_` defaults to `INVALID_DATA` (`node.h:198`); **no caller sets it**
-  (`setPredictedDepth` does not exist; `Grid::insert`/`GeoGrid::insert` never supply
-  one). So the guard at `node.cpp:93` is always false → slope correction is inert.
-- `Hypothesis::generateNullHypothesis(depth, var)` already exists (`hypothesis.h:43`)
-  — the port has the base-hypothesis primitive the original seeds from a prior.
-- `Grid` (`grid.cpp`) is a flat regular `x×y` array (`origin_`, `sizes_`, `counts_`)
-  → directly supports bilinear 4-NN interpolation. `GeoGrid` (`geo_grid.cpp`) is a
-  sparse `map<GridIndex,Node>` keyed by GGGS cell, iterated via `CellAreaIterator`.
-
-### Verified sign/quantity table (read from source, not assumed)
-
-| Quantity | Source | Convention / magnitude |
+| Claim | Source verified | Result |
 |---|---|---|
-| original `snd->depth` | `sounding.c:1278`, `sounding.h:423` | negative-down |
-| original `snd->range` | `sounding.c:1268` (pre-negation) | **positive**, `= \|depth\|/cos(angle)` |
-| original `node->pred_depth` | `cube_node.c` | negative-down (same as depth) |
-| original offset | `cube_node.c:1847` | `pred_depth − range` (both as above) |
-| port `sounding.depth` | `sounding.h` header | negative-down ("negative is down") |
-| port `sonar_relative_position.z` | `sounding.h:50` | `range·cos(tx)·cos(rx)` = **vertical comp**, positive-down, `= \|depth\|` |
-| port `predicted_depth_` | `node.h:198` | negative-down (compared against `sounding.depth` in blunder check) |
+| `range` overwritten with interpolated touchdown pred_depth | `mapsheet_cube.c:2417-2444` | ✓ verbatim |
+| offset = pred_depth − range (queued depth+offset) | `cube_node.c:1846-1862` | ✓ verbatim |
+| `cube_grid_interpolate` reads `pred_depth`, returns 0 if any corner no-data | `cube_grid.c:2360,2374-2384` | ✓ |
+| `cube_grid_insert_depths` never sets pred_depth / never interpolates | `cube_grid.c:1877-1992` | ✓ (only calls `cube_node_insert`) |
+| `pred_depth` seeded from external prior array | `cube_grid.c:1665,1712,1730` | ✓ |
+| `cube_node_set_preddepth` doc: INVALID ⇒ no slope correction | `cube_node.c:1066-1093` | ✓ |
+| port `predicted_depth_` negative-down, blunder-checked vs `sounding.depth` | `node.cpp:93-102`, `node.h:198` | ✓ |
+| port has no prior-load / no `setPredictedDepth` / no `Sounding.range` | `node.*`, `grid.cpp`, `geo_grid.cpp`, `sounding.h` | ✓ absent |
 
-**Correct port offset** (reproduces the original at all angles): reconstruct the
-slant-projected *signed* depth analog of `snd->range`, keeping the port's negative-down
-sign:
+## The crux: the port has NO predicted-surface mechanism — resolution
 
-```
-slant = |sonar_relative_position|              (full slant range, ≥ |z|)
-cos(angle) = |z| / slant                        (z = vertical comp)
-range_analog = sounding.depth / cos(angle)      (= sounding.depth * slant / |z|),
-                                                 negative-down, magnitude ≥ |depth|
-offset = predicted_depth_ - range_analog
-queued depth = sounding.depth + offset
-```
+A faithful port of *active* slope correction requires infrastructure the port **entirely
+lacks**: (a) a prior-surface load path (`cube_grid_initialise` analog: load prior bathymetry,
+seed `predicted_depth_` + base hypothesis per node), and (b) the per-sounding touchdown
+interpolation of that prior surface (`cube_grid_interpolate` + the `mapsheet_cube.c` `range`
+overwrite). Today `predicted_depth_` is `INVALID_DATA` everywhere and nothing sets it.
 
-Sanity vs original (boresight, rx=tx=0): `slant=|z|`, `cos=1`, `range_analog =
-sounding.depth`, `offset = pred − depth`, queued `= pred`. Off-boresight (e.g. rx=60°):
-`cos=0.5`, `range_analog = 2·depth` (still negative-down), `offset = pred − 2·depth`,
-queued `= depth + pred − 2·depth = pred − depth` — i.e. the node sees the prediction
-shifted by the slope-projected residual, **matching CUBE's `pred + (depth − range)`
-once both are in the same (negative-down) convention**. The prior plan's
-`pred + z` collapsed to exactly `pred` off-boresight, erasing the correction.
+The two rejected paths are off the table:
+- **Self-bootstrap from running estimates** — this is what v1/v2 reached for. It is *not*
+  the original (`cube_grid_insert_depths` sets no pred_depth; `cube_grid_interpolate` reads
+  `pred_depth`, not estimates). Shipping it would be inventing a new estimator and
+  mislabeling it a port. **Rejected — deviation from CUBE with no correctness argument.**
+- **A non-physical offset or a silently-dead block** — also rejected by the review.
 
-Guard `|z| > 0` (avoids div-by-zero; equivalent to the original's `range != 0.0`) and
-`predicted_depth_ != INVALID_DATA`.
+**Decision (documented deviation: none — faithful subset + scoped deferral):**
+This PR ports the **offset shape correctly and faithfully**, and **explicitly defers the
+active-correction behaviour** behind the missing external-prior subsystem, which is too
+large to build correctly under current pressure and is filed as a referenced follow-on.
+Concretely:
+
+- Add `Node::setPredictedDepth(depth, var)` — a faithful 1:1 port of
+  `cube_node_set_preddepth` (`cube_node.c:1084`). This is the real, named primitive; it is
+  not a stand-in for the prior pipeline.
+- Re-enable the offset with the **correct formula**: `offset = predicted_depth_(node) −
+  predicted_depth_at_touchdown`, where `predicted_depth_at_touchdown` is supplied **per
+  sounding** as a field on `Sounding` (the port's analog of the overwritten `snd->range` —
+  named `predicted_depth_at_touchdown`, NOT `range`, to avoid resurrecting the misread).
+  Guard exactly as the original: skip (offset 0) when the touchdown prediction is the
+  no-correction sentinel **or** `predicted_depth_` is `INVALID_DATA`.
+- **Do not** wire a predicted-surface producer in this PR. With no prior loaded,
+  `predicted_depth_` stays `INVALID_DATA` and `Sounding.predicted_depth_at_touchdown` stays
+  at its no-correction sentinel, so the offset is 0 — the **defined, safe, correct-but-
+  uncorrected** behaviour the grids already have today. This is *not* a dead block: it is a
+  correct, tested, fully-wired code path that activates the instant a predicted surface is
+  supplied. The block is exercised end-to-end by the integration test (which supplies a
+  synthetic prediction directly), so it is not silently-dead either.
+- **File the follow-on now** (referenced in the PR): "Port `cube_grid_initialise`
+  external-prior load + base-hypothesis seed, and the `mapsheet_cube.c` per-sounding
+  touchdown interpolation (`cube_grid_interpolate`) of `predicted_depth_at_touchdown`, to
+  make slope correction active in production." That issue is the home for the prior-surface
+  subsystem; this PR delivers the node-level math it will drive.
+
+This satisfies "fix it completely" at the achievable boundary: the part that *can* be
+ported faithfully and correctly now (the node math + primitive) is, with tests at the
+off-boresight cases where the prior bugs hid; the part that needs a whole subsystem is
+honestly scoped out and tracked, not faked.
+
+## Scope decision: Grid-only (and here, neither grid is wired — both stay at offset 0)
+
+Per the review: defer GeoGrid (and the GGGS bilinear analog) to a referenced follow-on.
+GeoGrid at offset-0 is **safe (correct-but-uncorrected), not dead**. In this PR the
+node-level offset is identical for both grids (it lives in `Node::insert`); since neither
+grid supplies a predicted surface yet, both run at offset 0 unchanged. The follow-on that
+builds the prior-surface producer is where Grid-vs-GeoGrid interpolation geometry gets
+decided — that is the right place for the GGGS divergence question, not here.
 
 ## Approach
 
-### Part A — Correct offset in `Node::insert`
+### Part A — Correct, faithful offset in `Node::insert`
 
-1. **Add a `range` field to `Sounding`** (`sounding.h`): a signed slant-projected
-   depth `= depth / cos(beam_angle)`, populated in the `SonarDetections` constructor
-   from the already-computed geometry (`range_analog = depth * slant / |z|`, with
-   `slant = hypot(x,y,z)`); leave it `0.0` (the "no correction" sentinel, matching the
-   original's `range != 0.0` guard) when `|z|` is 0 or the explicit-`depth`-only
-   constructor is used. Document the sign convention in a header comment and note this
-   field is the port's analog of the original `snd->range`.
+1. **Add `predicted_depth_at_touchdown` to `Sounding`** (`sounding.h`): a `float`
+   defaulting to a no-correction sentinel (`INVALID_DATA`, mirroring the original's
+   `range != 0.0` guard meaning "no interpolation result"). Document it as the port's analog
+   of the *overwritten* `snd->range` (interpolated prior-surface depth at the sounding
+   touchdown, negative-down) — explicitly **not** `depth/cos(angle)`. Leave both existing
+   constructors setting it to the sentinel (no producer yet).
 
-2. **Re-enable slope correction** (`node.cpp:117-124`): replace the commented block with
-   `if (sounding.range != 0.0 && predicted_depth_ != INVALID_DATA) offset =
-   predicted_depth_ - sounding.range;`. Add a comment block citing the sign derivation,
-   `sounding.c:1268`/`cube_node.c:1847`, and why it was originally disabled (missing
-   `range` field at port time). Correct the stale `parameters.no_data_value` sentinel in
-   the old comment to `INVALID_DATA` (matching the live guard at `node.cpp:93`).
-
-### Part B — Prior-surface prediction pipeline (makes correction execute)
-
-Replicate the original's **self-bootstrapped** mechanism (`cube_grid_interpolate`), the
-one that needs no external prior file — it is the production-relevant path:
+2. **Re-enable the offset** (`node.cpp:118-125`): replace the commented block with
+   ```cpp
+   if (sounding.predicted_depth_at_touchdown != INVALID_DATA &&
+       predicted_depth_ != INVALID_DATA) {
+     offset = predicted_depth_ - sounding.predicted_depth_at_touchdown;
+   }
+   ```
+   queued as `sounding.depth + offset` (unchanged). Add a comment block deriving the offset
+   as `pred_depth(node) − pred_depth(touchdown)` with the `cube_node.c:1846` +
+   `mapsheet_cube.c:2434` citations, stating why it was disabled at port time (no
+   `range`/predicted-surface field existed), and **correcting the stale
+   `parameters.no_data_value` sentinel** in the old comment to `INVALID_DATA` (matching the
+   live guard at `node.cpp:93`).
 
 3. **`Node::setPredictedDepth(float depth, float variance)`** (`node.h`/`node.cpp`):
-   faithful port of `cube_node_set_preddepth` — set `predicted_depth_` /
-   `predicted_depth_variance_`. Public so grid code can call it.
+   faithful 1:1 port of `cube_node_set_preddepth` (`cube_node.c:1084`) — sets
+   `predicted_depth_` / `predicted_depth_variance_`. Public, so the future prior-load path
+   (and the tests) can seed a predicted surface. Port the doc-comment sentinel conventions
+   verbatim (NaN ⇒ don't incorporate; INVALID ⇒ no prediction / no slope correction).
 
-4. **`Node` current-estimate accessor**: expose the node's current best-estimate
-   depth+variance (reuse `extractDepthAndUncertainty`) so the grid can read neighbour
-   estimates to interpolate from. (Original interpolates from `pred_depth`; the port's
-   equivalent stored prediction is the running best estimate.)
+### Part B — Tests (the bug hid off-boresight and at the offset semantics)
 
-5. **`Grid::interpolatePredictedDepth(MapPosition) -> optional<DepthAndUncertainty>`**
-   (`grid.cpp`): faithful port of `cube_grid_interpolate` — locate the 4-NN cell
-   (`floor(x/dx), floor(y/dy)`), read the 4 corner nodes' current estimates, return
-   `nullopt` if any corner lacks a valid estimate (mirrors original's "return 0.0 / no
-   correction"), else bilinear-interpolate depth and propagate variance (port the
-   `cube_grid_est_interp_error` weighting; if that proves heavy, document a simpler
-   variance-of-the-mean and flag as a follow-up — see Risks).
+Tests reconstruct the **original** `pred_depth(node) − pred_depth(touchdown)` independently
+from a known synthetic prior surface — never the rejected `pred` or `pred − depth/cos`.
 
-6. **Wire prediction into the insert path** (`Grid::insert`): before calling
-   `node->insert(...)` for each affected node, compute the predicted depth at that
-   **node's** position from its neighbours and `node->setPredictedDepth(...)`. Match the
-   original's ordering caveat: prediction is interpolated from *already-estimated*
-   neighbours, so on a cold grid the first soundings get no prediction (offset 0, exactly
-   as the original behaves until a surface forms) and correction strengthens as the
-   surface fills — verify this is the original's behaviour, do not invent a seeding rule.
+4. **`test_node.cpp`:**
+   - `SlopeCorrectionSurfaceSlopeDelta`: `setPredictedDepth(pred_node, var)`; a `Sounding`
+     with `predicted_depth_at_touchdown = pred_touchdown` for a **genuinely off-boresight**
+     touchdown on a known slope (e.g. `pred_node = -10`, `pred_touchdown = -10.6`,
+     `depth = -10.5`); assert the queued/extracted depth equals
+     `depth + (pred_node − pred_touchdown)` reconstructed independently in the test — the
+     surface-slope-delta result, **not** `pred` and **not** `pred − depth/cos(angle)`. This
+     is the test that catches all three prior-formula errors.
+   - `SlopeCorrectionZeroOnFlatSurface`: `pred_touchdown == pred_node` ⇒ offset 0 ⇒
+     queued `= depth`.
+   - `NoSlopeCorrectionWhenTouchdownSentinel` and `…WhenPredictedDepthInvalid`: offset stays
+     0 (queued `= depth`).
 
-7. **`GeoGrid::insert` parity** (`geo_grid.cpp`): provide the same prediction step for
-   the sparse geographic grid. The 4-NN concept maps onto the GGGS cell neighbourhood;
-   if exact bilinear over GGGS cells is non-trivial, port the nearest-estimated-neighbour
-   prediction faithfully and document any geometry divergence from the regular-grid case.
-   If this is genuinely large, it is the one sub-part that may warrant splitting into a
-   stacked follow-on PR (see Estimated Scope) — `Grid` is the testable core.
-
-### Part C — Tests
-
-8. **Off-boresight offset unit tests** (`test_node.cpp`):
-   - `SlopeCorrectionOffBoresight`: `setPredictedDepth(-10, var)`; a `Sounding` with a
-     genuinely off-boresight beam (e.g. rx=60° so `range_analog = 2·depth`),
-     `depth=-9`; assert the queued/extracted depth equals the **original CUBE**
-     reconstruction `pred − depth_offset` (computed independently in the test from
-     `pred_depth − depth/cos(angle)`), **not** the prior plan's `pred`. This is the
-     test that would have caught the bug.
-   - `SlopeCorrectionBoresightMatchesOriginal`: boresight beam → queued depth `= pred`.
-   - `NoSlopeCorrectionWhenRangeZero` and `…WhenPredInvalid`: offset stays 0.
-
-9. **Interpolation unit test** (`test_grid.cpp`): build a `Grid`, seed 4 corner nodes
-   with a known synthetic slope, assert `interpolatePredictedDepth` at the centre equals
-   the bilinear value and returns `nullopt` when a corner is unset.
-
-10. **End-to-end integration test** (`test_grid.cpp`, new
-    `SlopeCorrectionImprovesEstimateOnSlope`): on a known synthetic planar slope, insert
-    off-node soundings through `Grid::insert` (prediction → corrected insert) and assert
-    the corrected node estimate is closer to ground truth than the same run with
-    correction disabled (predicted depth withheld). This proves the pipeline executes
-    and helps, not just compiles.
+5. **`test_grid.cpp` integration** (`SlopeCorrectionAppliesOnSeededSurface`): seed a small
+   `Grid`'s nodes with a known synthetic planar slope via `setPredictedDepth`, construct
+   off-node soundings whose `predicted_depth_at_touchdown` is set (in the test) to the
+   surface value at their touchdown, run `Grid::insert`, and assert the corrected node
+   estimates reflect `depth + (pred_node − pred_touchdown)` — i.e. the wired path executes
+   end-to-end. A paired run with the touchdown sentinel left unset asserts offset-0
+   (cold-grid / no-prior behaviour), proving the safe default. This demonstrates the block
+   is live-and-correct when fed a prediction, and safe (offset 0) when not — directly
+   answering "not a silently-dead block."
 
 ## Files to Change
 
 | File | Change |
 |------|--------|
-| `cube_bathymetry/include/cube_bathymetry/sounding.h` | Add signed `range` field + populate in `SonarDetections` ctor; doc sign convention |
-| `cube_bathymetry/include/cube_bathymetry/node.h` | Declare `setPredictedDepth`, current-estimate accessor |
-| `cube_bathymetry/src/node.cpp` | Re-enable corrected slope offset; implement `setPredictedDepth`/accessor; comments + sentinel fix |
-| `cube_bathymetry/include/cube_bathymetry/grid.h` | Declare `interpolatePredictedDepth` |
-| `cube_bathymetry/src/grid.cpp` | Implement bilinear prediction; wire into `insert` before `node->insert` |
-| `cube_bathymetry/include/cube_bathymetry/geo_grid.h` | Declare prediction helper (GeoGrid parity) |
-| `cube_bathymetry/src/geo_grid.cpp` | Prediction step in `insert` (or document split to follow-on) |
-| `cube_bathymetry/test/test_node.cpp` | Off-boresight + boresight + zero/invalid offset tests |
-| `cube_bathymetry/test/test_grid.cpp` | Interpolation unit test + end-to-end slope integration test |
+| `cube_bathymetry/include/cube_bathymetry/sounding.h` | Add `predicted_depth_at_touchdown` field (sentinel default) + doc; set sentinel in both ctors |
+| `cube_bathymetry/include/cube_bathymetry/node.h` | Declare `setPredictedDepth(float,float)` |
+| `cube_bathymetry/src/node.cpp` | Re-enable corrected offset (`pred_depth − touchdown`); implement `setPredictedDepth`; comments + sentinel fix |
+| `cube_bathymetry/test/test_node.cpp` | Surface-slope-delta + flat + sentinel + invalid offset tests |
+| `cube_bathymetry/test/test_grid.cpp` | Seeded-surface integration test (live path) + cold-grid offset-0 test |
+
+No change to `grid.cpp` / `geo_grid.cpp` in this PR (no predicted-surface producer is
+wired — see crux). They continue to run at offset 0 as today.
 
 ## Principles Self-Check
 
 | Principle | Consideration |
 |---|---|
-| Fix it completely | Both review-plan must-fixes addressed: correct slant-range analog (not `.z`) and a working prediction pipeline, not dead code. Tests hit off-boresight where the bug hid. |
-| Never document from assumptions | Offset/sign derived from `sounding.c:1268/1278`, `cube_node.c:1846`, `cube_grid.c:2360/1666`; port types read from `sounding.h`, `node.h`, `grid.cpp`, `geo_grid.cpp`, `hypothesis.h`. |
-| Robustness | Guards: `range != 0.0`, `predicted_depth_ != INVALID_DATA`, `nullopt` when 4-NN incomplete, div-by-zero guard on `|z|`. Faithful to original cold-grid behaviour. |
-| Replicate, don't invent | Prediction = port of `cube_grid_interpolate` + `cube_node_set_preddepth`; not a new scheme. Divergences (variance model, GeoGrid geometry) called out, not hidden. |
+| Replicate, don't invent | Offset is the verified `pred_depth(node) − pred_depth(touchdown)` surface delta; `setPredictedDepth` is a 1:1 port of `cube_node_set_preddepth`. The rejected self-bootstrap path is explicitly not implemented. |
+| Never document from assumptions | Every formula/sign claim cited to `mapsheet_cube.c:2434`, `cube_node.c:1846`, `cube_grid.c:2360/1665/1712`, `cube_node.c:1084`, re-read for this plan (Verification table). |
+| Fix it completely | The faithfully-portable part (node math + primitive) ships fully tested at off-boresight/slope cases; the part needing a whole prior-surface subsystem is scoped out and FILED, not faked or half-built. |
+| Robustness / no silent corruption | No `1/cos²` obliquity error (the v1/v2 bug); guards (`INVALID_DATA` on both pred + touchdown) reproduce the original's `range != 0.0 && pred != no_data` exactly; default behaviour is offset-0 (safe), not a non-physical correction. |
+| Human control / transparency | Re-enabled path is inert-but-correct until a prior surface is supplied; the follow-on issue documents the remaining subsystem so no hidden half-feature lands. |
 
 ## ADR Compliance
 
 | ADR | Triggered | How addressed |
 |---|---|---|
-| None | No | Pure algorithmic faithful-port; no new topics/params/QoS/lifecycle. The `range` field on the internal `Sounding` struct is not a ROS message change. |
+| None | No | Pure algorithmic faithful-port; no ROS topics/params/QoS/lifecycle. `predicted_depth_at_touchdown` is an internal `Sounding` field, not a ROS message change. |
 
 ## Consequences
 
 | If we change... | Also update... | Included? |
 |---|---|---|
-| `Sounding` adds `range` | both ctors (`SonarDetections` + explicit-depth) | Yes — Part A.1 |
-| `Node::insert` offset | `setPredictedDepth` accessor (new) | Yes — Part B |
-| `Grid::insert` prediction step | `GeoGrid::insert` parity | Yes — Part B.7 (or split, see scope) |
-| New offset/pipeline | `test_node.cpp` + `test_grid.cpp` | Yes — Part C |
-| Variance interpolation model | `cube_grid_est_interp_error` fidelity | Partial — port faithfully or flag simplification (Risks) |
+| `Sounding` adds `predicted_depth_at_touchdown` | both ctors set the sentinel | Yes — A.1 |
+| `Node::insert` offset re-enabled | `setPredictedDepth` primitive (new) | Yes — A.3 |
+| Offset re-enabled but no producer | follow-on issue for `cube_grid_initialise` prior-load + `cube_grid_interpolate` touchdown interp (Grid + GeoGrid geometry) | Yes — filed + referenced in PR |
+| New offset/primitive | `test_node.cpp` + `test_grid.cpp` | Yes — Part B |
 
 ## Open Questions
 
-- [ ] **GeoGrid bilinear geometry**: regular-grid bilinear has no exact GGGS-cell analog.
-  Acceptable to port nearest-estimated-neighbour prediction for `GeoGrid` and document
-  the divergence, or must GeoGrid match `Grid` exactly before merge?
-- [ ] **PR shape**: land Part A+B(Grid)+C as one PR and stack GeoGrid parity as a
-  follow-on if it proves large, or insist on a single PR covering both grids?
-
-## Risks (honest read — this is larger than the issue implied)
-
-- **The interpolation pipeline (Part B) is the bulk of the work and the real risk.** The
-  one-line offset (Part A) is small; building faithful prior-surface prediction and
-  wiring it into two different grid representations (regular `Grid` + sparse GGGS
-  `GeoGrid`) is a non-trivial port. The original's variance-propagation
-  (`cube_grid_est_interp_error`, `cube_grid.c:2306`) is fiddly and may need its own
-  careful port or a documented simplification.
-- **Cold-grid / ordering coupling**: prediction reads already-estimated neighbours, so
-  results depend on sounding insert order until the surface fills. This matches the
-  original but makes the integration test sensitive to construction; the test must use a
-  surface that is pre-seeded or inserted in an order that exercises the corrected path
-  deterministically.
-- **Mitigation / fallback**: if GeoGrid parity balloons under the ~2-day deployment
-  pressure, the defensible minimum is Part A + Part B for `Grid` + all of Part C
-  (off-boresight correctness proven end-to-end on the regular grid), with GeoGrid parity
-  as an explicitly-filed stacked follow-on issue — **not** a silently-dead path.
+- [ ] **Sentinel for `predicted_depth_at_touchdown`**: plan uses `INVALID_DATA` to mirror the
+  original's `range != 0.0` guard. Confirm `INVALID_DATA` (= `float::max`) is the right
+  "no-correction" sentinel here vs. `0.0` (the literal original test). `INVALID_DATA` is
+  preferred because a *legitimately interpolated* touchdown depth could be `0.0`; flag for
+  review.
+- [ ] **Follow-on title/scope**: confirm the prior-surface subsystem (external-prior load +
+  touchdown interpolation, Grid + GeoGrid) is one follow-on issue, or split prior-load from
+  interpolation. Recommend one umbrella issue, since they only deliver value together.
 
 ## Estimated Scope
 
-**Single PR if GeoGrid parity is tractable; otherwise a 2-PR stack** (Part A + Part B
-for `Grid` + Part C first; GeoGrid prediction parity second). This is materially larger
-than a "re-enable one block" change — it builds a prediction subsystem. The plan flags
-the split point rather than understating the size.
+**Single small PR.** Three production edits (one `Sounding` field, the offset re-enable, the
+`setPredictedDepth` primitive) plus focused tests. The large, risky part — the prior-surface
+prediction subsystem the v2 plan tried to fold in — is correctly *out* of this PR and filed
+as a referenced follow-on. Size/risk read after three passes: **low**. The remaining risk is
+the sentinel-convention choice (Open Question 1), settled at review.

--- a/.agent/work-plans/issue-15/plan.md
+++ b/.agent/work-plans/issue-15/plan.md
@@ -174,15 +174,25 @@ from a known synthetic prior surface — never the rejected `pred` or `pred − 
    - `NoSlopeCorrectionWhenTouchdownSentinel` and `…WhenPredictedDepthInvalid`: offset stays
      0 (queued `= depth`).
 
-5. **`test_grid.cpp` integration** (`SlopeCorrectionAppliesOnSeededSurface`): seed a small
-   `Grid`'s nodes with a known synthetic planar slope via `setPredictedDepth`, construct
-   off-node soundings whose `predicted_depth_at_touchdown` is set (in the test) to the
-   surface value at their touchdown, run `Grid::insert`, and assert the corrected node
-   estimates reflect `depth + (pred_node − pred_touchdown)` — i.e. the wired path executes
-   end-to-end. A paired run with the touchdown sentinel left unset asserts offset-0
-   (cold-grid / no-prior behaviour), proving the safe default. This demonstrates the block
-   is live-and-correct when fed a prediction, and safe (offset 0) when not — directly
-   answering "not a silently-dead block."
+5. **Synthetic-injection integration test** (`SlopeCorrectionSurfaceSlopeDelta`, in
+   `test_node.cpp`): seed a `Node`'s predicted surface via `setPredictedDepth(pred_node, var)`,
+   construct off-node soundings whose `predicted_depth_at_touchdown` is set (in the test) to
+   the surface value at their touchdown, drive the **full** `Node::insert` → `queueFlush` →
+   `extractDepthAndUncertainty` pipeline, and assert the converged estimate reflects
+   `depth + (pred_node − pred_touchdown)` — i.e. the wired path executes end-to-end. The
+   paired `NoSlopeCorrectionWhenTouchdownSentinel` / `…WhenPredictedDepthInvalid` cases assert
+   offset-0 (cold / no-prior behaviour), proving the safe default. Together these demonstrate
+   the block is live-and-correct when fed a prediction, and safe (offset 0) when not —
+   directly answering "not a silently-dead block."
+
+   **Deviation from earlier draft (this file → `test_grid.cpp`):** `Grid` and `GeoGrid` keep
+   `nodes_` private and expose **no** per-node seed API, so `predicted_depth_` cannot be set
+   through the grid public surface. The end-to-end injection test therefore lives at the
+   **`Node`** level — the shared integration point both `Grid::insert` and `GeoGrid::insert`
+   call (`grid.cpp:122`, `geo_grid.cpp:95`) — driving the identical pipeline. Adding a
+   node-seed API to the grids is the deferred predicted-surface producer's concern (it is what
+   `cube_grid_initialise` does), not this PR's; introducing a test-only grid accessor now would
+   add production surface area ahead of that subsystem. No `test_grid.cpp` change in this PR.
 
 ## Files to Change
 
@@ -191,8 +201,8 @@ from a known synthetic prior surface — never the rejected `pred` or `pred − 
 | `cube_bathymetry/include/cube_bathymetry/sounding.h` | Add `predicted_depth_at_touchdown` field (sentinel default) + doc; set sentinel in both ctors |
 | `cube_bathymetry/include/cube_bathymetry/node.h` | Declare `setPredictedDepth(float,float)` |
 | `cube_bathymetry/src/node.cpp` | Re-enable corrected offset (`pred_depth − touchdown`); implement `setPredictedDepth`; comments + sentinel fix |
-| `cube_bathymetry/test/test_node.cpp` | Surface-slope-delta + flat + sentinel + invalid offset tests |
-| `cube_bathymetry/test/test_grid.cpp` | Seeded-surface integration test (live path) + cold-grid offset-0 test |
+| `cube_bathymetry/test/test_node.cpp` | Surface-slope-delta + flat + sentinel + invalid offset tests, AND the synthetic-injection end-to-end test (seed `setPredictedDepth` + touchdown → insert→flush→extract) |
+| ~~`cube_bathymetry/test/test_grid.cpp`~~ | **No change** — Grid/GeoGrid expose no node-seed API; the end-to-end injection test lives in `test_node.cpp` at the shared `Node::insert` integration point (see Part B.5 deviation) |
 
 No change to `grid.cpp` / `geo_grid.cpp` in this PR (no predicted-surface producer is
 wired — see crux). They continue to run at offset 0 as today.

--- a/.agent/work-plans/issue-15/plan.md
+++ b/.agent/work-plans/issue-15/plan.md
@@ -1,0 +1,131 @@
+# Plan: Slope correction is disabled (commented out) in Node::insert
+
+## Issue
+
+https://github.com/rolker/cube_bathymetry/issues/15
+
+## Context
+
+The original CUBE C code (`original_cube/libsrc/cube/cube_node.c:1846-1862`) applies a
+slope correction offset when a predicted depth is available and the sounding's boresight
+range is non-zero:
+
+```c
+if (snd->range != 0.0 && node->pred_depth != p->no_data_value) {
+    offset = node->pred_depth - snd->range;
+}
+```
+
+In the ROS 2 port (`cube_bathymetry/src/node.cpp:117-124`) this entire block is
+commented out; `offset` is always 0.0. The commented code referenced `sounding.range`,
+a field that was never added to the port's `Sounding` struct — this is why it was
+left disabled at port time.
+
+The port already carries the equivalent data in
+`Sounding::sonar_relative_position.z`, which is computed as
+`range * cos(tx_angle) * cos(rx_angles[i])` — the vertical component of the slant
+range from the sonar to the detection (positive = down). This is the correct analog
+for the original's `snd->range` field.
+
+### Sign convention (verified against source)
+
+| Quantity | Sign convention |
+|---|---|
+| `Sounding::depth` | Negative below surface (per header comment: "Positive is up above sea surface and negative is down below") |
+| `predicted_depth_` | Same as `depth` — negative below surface (used as `target_depth` in blunder comparisons against `sounding.depth`) |
+| `sonar_relative_position.z` | Positive down (computed as `range * cos(…) * cos(…)`, always positive for a downward sonar) |
+| Original `snd->range` | Positive down (hydrographic positive-below-surface convention) |
+| Original `node->pred_depth` | Positive down (original CUBE hydrographic convention) |
+
+The original offset is `pred_depth_orig - range_orig` where both are positive-down.
+In the port, `predicted_depth_` is negative-down and `sonar_relative_position.z` is
+positive-down, so:
+
+```
+offset_port = predicted_depth_ - (-sonar_relative_position.z)
+            = predicted_depth_ + sonar_relative_position.z
+```
+
+The commented-out formula `predicted_depth_ - sounding.range` has the wrong sign for
+the port's depth convention.
+
+### Missing setter
+
+`predicted_depth_` has no public setter in the port. The original sets it via
+`cube_node_set_preddepth()` called from the map sheet after interpolating a prior
+surface. Without a setter (and call site in Grid/GeoGrid), slope correction will
+never fire even after re-enabling. Adding the setter is in scope for this issue;
+hooking it into a per-node interpolation pass in Grid/GeoGrid is a larger follow-on
+(the port doesn't yet have a prior-surface interpolation pipeline).
+
+## Approach
+
+1. **Fix the formula and re-enable slope correction in `Node::insert`** — replace the
+   commented block with the corrected expression using `sonar_relative_position.z`.
+   Guard condition: `sonar_relative_position.z != 0.0` (matches original's
+   `snd->range != 0.0`) and `predicted_depth_ != INVALID_DATA`. Add a comment
+   explaining (a) the sign-convention derivation and (b) why this was originally
+   commented out (no `range` field at port time; the `sonar_relative_position.z`
+   field was the fix).
+
+2. **Add `setPredictedDepth()` to `Node`** — expose a public method so grid-level
+   code can supply the interpolated predicted surface depth and variance before
+   calling `insert`. Without this, slope correction remains unreachable.
+
+3. **Add slope-correction test in `test_node.cpp`** — add a
+   `SlopeCorrectionAppliesOffset` test:
+   - Set `predicted_depth_` via `setPredictedDepth()` to a known value (e.g., -10.0)
+   - Construct a `Sounding` with `sonar_relative_position.z = 9.0` (node is 1m
+     shallower than boresight) and `depth = -9.0`
+   - Insert with distance small enough to pass capture and blunder checks
+   - Flush the queue and extract depth
+   - Assert the extracted depth reflects the corrected value
+     (`-9.0 + (-10.0 + 9.0) = -10.0`)
+   - Add a zero-z `NoSlopeCorrectionWhenZero` test confirming offset stays 0.0
+
+4. **Comment: why originally disabled** — add an inline comment block at the
+   re-enabled slope correction explaining that `sounding.range` was the missing
+   field at port time and that `sonar_relative_position.z` is now the equivalent.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `cube_bathymetry/src/node.cpp` | Re-enable slope correction with corrected sign; add explanatory comments |
+| `cube_bathymetry/include/cube_bathymetry/node.h` | Add `setPredictedDepth(float depth, float variance)` declaration |
+| `cube_bathymetry/test/test_node.cpp` | Add `SlopeCorrectionAppliesOffset` and `NoSlopeCorrectionWhenZero` tests |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Fix it completely | The formula sign bug is fixed, the setter is added, and tests cover both the corrected and the zero-z paths. The grid-integration follow-on is called out explicitly rather than left silent. |
+| Never document from assumptions | Sign convention derived from reading `sounding.h` (header comment), `node.cpp` blunder comparisons, `original_cube/libsrc/cube/cube_node.c`, and `original_cube/libsrc/sounding/sounding.h`. |
+| Robustness | Guard conditions match the original (`z != 0.0` and `predicted_depth_ != INVALID_DATA`). |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| None directly triggered | — | Change is a pure algorithmic re-enable within an existing file; no new topics, parameters, or architecture changes. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `Node::insert` slope correction | `Node::setPredictedDepth` (new, must be added) | Yes — step 2 |
+| `setPredictedDepth` API | Grid/GeoGrid callers that will eventually supply predicted surface | No — follow-on; noted as open question |
+| Slope correction enabled | Tests | Yes — step 3 |
+
+## Open Questions
+
+- **Grid integration follow-on**: Should a new issue be filed now to track hooking
+  `setPredictedDepth` into Grid/GeoGrid after a prior-surface interpolation pass, or
+  is that left for discovery when the interpolation pipeline is built? This plan does
+  not implement the grid-level call site — slope correction will compile and have a
+  test, but will remain inactive in production until a caller sets the predicted depth.
+
+## Estimated Scope
+
+Single PR. Three files changed; no new dependencies; no API surface beyond the one new
+public method. Test additions are self-contained.

--- a/.agent/work-plans/issue-15/plan.md
+++ b/.agent/work-plans/issue-15/plan.md
@@ -1,131 +1,247 @@
-# Plan: Slope correction is disabled (commented out) in Node::insert
+# Plan: Slope correction is disabled (commented out) in Node::insert — FULL FIX
 
 ## Issue
 
 https://github.com/rolker/cube_bathymetry/issues/15
 
+**This is a re-plan with expanded scope** (operator decision). The prior plan only
+re-enabled the dormant block; `review-plan` rejected it (wrong formula + runtime-inert).
+This plan fixes **both**: the correct slant-range offset analog AND the prior-surface
+prediction pipeline that makes slope correction execute end-to-end.
+
 ## Context
 
-The original CUBE C code (`original_cube/libsrc/cube/cube_node.c:1846-1862`) applies a
-slope correction offset when a predicted depth is available and the sounding's boresight
-range is non-zero:
+### What the original CUBE actually does
 
-```c
-if (snd->range != 0.0 && node->pred_depth != p->no_data_value) {
-    offset = node->pred_depth - snd->range;
-}
+Slope correction lets a sounding that touches down off-node be projected to the node
+along the local seabed slope, instead of being treated as a vertical measurement at the
+node. Two pieces are required and both exist in the original:
+
+1. **The offset** (`cube_node.c:1846`):
+   ```c
+   if (snd->range != 0.0 && node->pred_depth != p->no_data_value)
+       offset = node->pred_depth - snd->range;   // queued as snd->depth + offset
+   ```
+   `snd->range` is **not** a horizontal/slant distance — it is a *slant-projected
+   signed depth*: `range = depth / cos(beam_angle)` (`sounding.c:1268`), computed
+   **while `depth` is still positive** (depth is negated to negative-down only later,
+   `sounding.c:1278`). So in final convention `snd->depth` is negative-down and
+   `snd->range` is **positive**, magnitude `|depth|/cos(angle) ≥ |depth|`. At boresight
+   (`angle=0`) `range = |depth|`; off-boresight `range > |depth|`.
+
+2. **The prediction (`pred_depth`)** — produced two ways in the original:
+   - **External prior surface**: `cube_grid_initialise` / `cube_grid_init_unct`
+     (`cube_grid.c:1666,1773`) loop every node and call
+     `cube_node_set_preddepth(node, depth, var)` from a supplied prior bathymetry
+     array, then seed a base hypothesis via `cube_node_add_null_hypothesis`.
+   - **Self-bootstrapped from current estimates**: `cube_grid_interpolate`
+     (`cube_grid.c:2360`) does bilinear interpolation of the **4 nearest nodes'
+     current `pred_depth`** to predict depth at an arbitrary point; returns `0.0`
+     (no correction) unless all 4 corners have valid `pred_depth`.
+
+The convention sentinels (`cube_node.c:1078`, `cube_node_set_preddepth` doc):
+`pred_depth == NaN` ⇒ do not incorporate data; `pred_depth == INVALID` ⇒ no prediction
+available, no slope correction (offset 0). The port already mirrors these in
+`Node::insert` (`node.cpp:83,93`).
+
+### The port today
+
+- `Sounding` (`sounding.h`) has **no `range` field**. It has
+  `sonar_relative_position.z = range * cos(tx) * cos(rx)` — the **vertical component**
+  of the slant range (= `|depth|`, positive-down), which is the *wrong* analog for
+  `snd->range` (the prior plan's bug: differs by `1/cos²`, not a sign flip).
+- `predicted_depth_` defaults to `INVALID_DATA` (`node.h:198`); **no caller sets it**
+  (`setPredictedDepth` does not exist; `Grid::insert`/`GeoGrid::insert` never supply
+  one). So the guard at `node.cpp:93` is always false → slope correction is inert.
+- `Hypothesis::generateNullHypothesis(depth, var)` already exists (`hypothesis.h:43`)
+  — the port has the base-hypothesis primitive the original seeds from a prior.
+- `Grid` (`grid.cpp`) is a flat regular `x×y` array (`origin_`, `sizes_`, `counts_`)
+  → directly supports bilinear 4-NN interpolation. `GeoGrid` (`geo_grid.cpp`) is a
+  sparse `map<GridIndex,Node>` keyed by GGGS cell, iterated via `CellAreaIterator`.
+
+### Verified sign/quantity table (read from source, not assumed)
+
+| Quantity | Source | Convention / magnitude |
+|---|---|---|
+| original `snd->depth` | `sounding.c:1278`, `sounding.h:423` | negative-down |
+| original `snd->range` | `sounding.c:1268` (pre-negation) | **positive**, `= \|depth\|/cos(angle)` |
+| original `node->pred_depth` | `cube_node.c` | negative-down (same as depth) |
+| original offset | `cube_node.c:1847` | `pred_depth − range` (both as above) |
+| port `sounding.depth` | `sounding.h` header | negative-down ("negative is down") |
+| port `sonar_relative_position.z` | `sounding.h:50` | `range·cos(tx)·cos(rx)` = **vertical comp**, positive-down, `= \|depth\|` |
+| port `predicted_depth_` | `node.h:198` | negative-down (compared against `sounding.depth` in blunder check) |
+
+**Correct port offset** (reproduces the original at all angles): reconstruct the
+slant-projected *signed* depth analog of `snd->range`, keeping the port's negative-down
+sign:
+
+```
+slant = |sonar_relative_position|              (full slant range, ≥ |z|)
+cos(angle) = |z| / slant                        (z = vertical comp)
+range_analog = sounding.depth / cos(angle)      (= sounding.depth * slant / |z|),
+                                                 negative-down, magnitude ≥ |depth|
+offset = predicted_depth_ - range_analog
+queued depth = sounding.depth + offset
 ```
 
-In the ROS 2 port (`cube_bathymetry/src/node.cpp:117-124`) this entire block is
-commented out; `offset` is always 0.0. The commented code referenced `sounding.range`,
-a field that was never added to the port's `Sounding` struct — this is why it was
-left disabled at port time.
+Sanity vs original (boresight, rx=tx=0): `slant=|z|`, `cos=1`, `range_analog =
+sounding.depth`, `offset = pred − depth`, queued `= pred`. Off-boresight (e.g. rx=60°):
+`cos=0.5`, `range_analog = 2·depth` (still negative-down), `offset = pred − 2·depth`,
+queued `= depth + pred − 2·depth = pred − depth` — i.e. the node sees the prediction
+shifted by the slope-projected residual, **matching CUBE's `pred + (depth − range)`
+once both are in the same (negative-down) convention**. The prior plan's
+`pred + z` collapsed to exactly `pred` off-boresight, erasing the correction.
 
-The port already carries the equivalent data in
-`Sounding::sonar_relative_position.z`, which is computed as
-`range * cos(tx_angle) * cos(rx_angles[i])` — the vertical component of the slant
-range from the sonar to the detection (positive = down). This is the correct analog
-for the original's `snd->range` field.
-
-### Sign convention (verified against source)
-
-| Quantity | Sign convention |
-|---|---|
-| `Sounding::depth` | Negative below surface (per header comment: "Positive is up above sea surface and negative is down below") |
-| `predicted_depth_` | Same as `depth` — negative below surface (used as `target_depth` in blunder comparisons against `sounding.depth`) |
-| `sonar_relative_position.z` | Positive down (computed as `range * cos(…) * cos(…)`, always positive for a downward sonar) |
-| Original `snd->range` | Positive down (hydrographic positive-below-surface convention) |
-| Original `node->pred_depth` | Positive down (original CUBE hydrographic convention) |
-
-The original offset is `pred_depth_orig - range_orig` where both are positive-down.
-In the port, `predicted_depth_` is negative-down and `sonar_relative_position.z` is
-positive-down, so:
-
-```
-offset_port = predicted_depth_ - (-sonar_relative_position.z)
-            = predicted_depth_ + sonar_relative_position.z
-```
-
-The commented-out formula `predicted_depth_ - sounding.range` has the wrong sign for
-the port's depth convention.
-
-### Missing setter
-
-`predicted_depth_` has no public setter in the port. The original sets it via
-`cube_node_set_preddepth()` called from the map sheet after interpolating a prior
-surface. Without a setter (and call site in Grid/GeoGrid), slope correction will
-never fire even after re-enabling. Adding the setter is in scope for this issue;
-hooking it into a per-node interpolation pass in Grid/GeoGrid is a larger follow-on
-(the port doesn't yet have a prior-surface interpolation pipeline).
+Guard `|z| > 0` (avoids div-by-zero; equivalent to the original's `range != 0.0`) and
+`predicted_depth_ != INVALID_DATA`.
 
 ## Approach
 
-1. **Fix the formula and re-enable slope correction in `Node::insert`** — replace the
-   commented block with the corrected expression using `sonar_relative_position.z`.
-   Guard condition: `sonar_relative_position.z != 0.0` (matches original's
-   `snd->range != 0.0`) and `predicted_depth_ != INVALID_DATA`. Add a comment
-   explaining (a) the sign-convention derivation and (b) why this was originally
-   commented out (no `range` field at port time; the `sonar_relative_position.z`
-   field was the fix).
+### Part A — Correct offset in `Node::insert`
 
-2. **Add `setPredictedDepth()` to `Node`** — expose a public method so grid-level
-   code can supply the interpolated predicted surface depth and variance before
-   calling `insert`. Without this, slope correction remains unreachable.
+1. **Add a `range` field to `Sounding`** (`sounding.h`): a signed slant-projected
+   depth `= depth / cos(beam_angle)`, populated in the `SonarDetections` constructor
+   from the already-computed geometry (`range_analog = depth * slant / |z|`, with
+   `slant = hypot(x,y,z)`); leave it `0.0` (the "no correction" sentinel, matching the
+   original's `range != 0.0` guard) when `|z|` is 0 or the explicit-`depth`-only
+   constructor is used. Document the sign convention in a header comment and note this
+   field is the port's analog of the original `snd->range`.
 
-3. **Add slope-correction test in `test_node.cpp`** — add a
-   `SlopeCorrectionAppliesOffset` test:
-   - Set `predicted_depth_` via `setPredictedDepth()` to a known value (e.g., -10.0)
-   - Construct a `Sounding` with `sonar_relative_position.z = 9.0` (node is 1m
-     shallower than boresight) and `depth = -9.0`
-   - Insert with distance small enough to pass capture and blunder checks
-   - Flush the queue and extract depth
-   - Assert the extracted depth reflects the corrected value
-     (`-9.0 + (-10.0 + 9.0) = -10.0`)
-   - Add a zero-z `NoSlopeCorrectionWhenZero` test confirming offset stays 0.0
+2. **Re-enable slope correction** (`node.cpp:117-124`): replace the commented block with
+   `if (sounding.range != 0.0 && predicted_depth_ != INVALID_DATA) offset =
+   predicted_depth_ - sounding.range;`. Add a comment block citing the sign derivation,
+   `sounding.c:1268`/`cube_node.c:1847`, and why it was originally disabled (missing
+   `range` field at port time). Correct the stale `parameters.no_data_value` sentinel in
+   the old comment to `INVALID_DATA` (matching the live guard at `node.cpp:93`).
 
-4. **Comment: why originally disabled** — add an inline comment block at the
-   re-enabled slope correction explaining that `sounding.range` was the missing
-   field at port time and that `sonar_relative_position.z` is now the equivalent.
+### Part B — Prior-surface prediction pipeline (makes correction execute)
+
+Replicate the original's **self-bootstrapped** mechanism (`cube_grid_interpolate`), the
+one that needs no external prior file — it is the production-relevant path:
+
+3. **`Node::setPredictedDepth(float depth, float variance)`** (`node.h`/`node.cpp`):
+   faithful port of `cube_node_set_preddepth` — set `predicted_depth_` /
+   `predicted_depth_variance_`. Public so grid code can call it.
+
+4. **`Node` current-estimate accessor**: expose the node's current best-estimate
+   depth+variance (reuse `extractDepthAndUncertainty`) so the grid can read neighbour
+   estimates to interpolate from. (Original interpolates from `pred_depth`; the port's
+   equivalent stored prediction is the running best estimate.)
+
+5. **`Grid::interpolatePredictedDepth(MapPosition) -> optional<DepthAndUncertainty>`**
+   (`grid.cpp`): faithful port of `cube_grid_interpolate` — locate the 4-NN cell
+   (`floor(x/dx), floor(y/dy)`), read the 4 corner nodes' current estimates, return
+   `nullopt` if any corner lacks a valid estimate (mirrors original's "return 0.0 / no
+   correction"), else bilinear-interpolate depth and propagate variance (port the
+   `cube_grid_est_interp_error` weighting; if that proves heavy, document a simpler
+   variance-of-the-mean and flag as a follow-up — see Risks).
+
+6. **Wire prediction into the insert path** (`Grid::insert`): before calling
+   `node->insert(...)` for each affected node, compute the predicted depth at that
+   **node's** position from its neighbours and `node->setPredictedDepth(...)`. Match the
+   original's ordering caveat: prediction is interpolated from *already-estimated*
+   neighbours, so on a cold grid the first soundings get no prediction (offset 0, exactly
+   as the original behaves until a surface forms) and correction strengthens as the
+   surface fills — verify this is the original's behaviour, do not invent a seeding rule.
+
+7. **`GeoGrid::insert` parity** (`geo_grid.cpp`): provide the same prediction step for
+   the sparse geographic grid. The 4-NN concept maps onto the GGGS cell neighbourhood;
+   if exact bilinear over GGGS cells is non-trivial, port the nearest-estimated-neighbour
+   prediction faithfully and document any geometry divergence from the regular-grid case.
+   If this is genuinely large, it is the one sub-part that may warrant splitting into a
+   stacked follow-on PR (see Estimated Scope) — `Grid` is the testable core.
+
+### Part C — Tests
+
+8. **Off-boresight offset unit tests** (`test_node.cpp`):
+   - `SlopeCorrectionOffBoresight`: `setPredictedDepth(-10, var)`; a `Sounding` with a
+     genuinely off-boresight beam (e.g. rx=60° so `range_analog = 2·depth`),
+     `depth=-9`; assert the queued/extracted depth equals the **original CUBE**
+     reconstruction `pred − depth_offset` (computed independently in the test from
+     `pred_depth − depth/cos(angle)`), **not** the prior plan's `pred`. This is the
+     test that would have caught the bug.
+   - `SlopeCorrectionBoresightMatchesOriginal`: boresight beam → queued depth `= pred`.
+   - `NoSlopeCorrectionWhenRangeZero` and `…WhenPredInvalid`: offset stays 0.
+
+9. **Interpolation unit test** (`test_grid.cpp`): build a `Grid`, seed 4 corner nodes
+   with a known synthetic slope, assert `interpolatePredictedDepth` at the centre equals
+   the bilinear value and returns `nullopt` when a corner is unset.
+
+10. **End-to-end integration test** (`test_grid.cpp`, new
+    `SlopeCorrectionImprovesEstimateOnSlope`): on a known synthetic planar slope, insert
+    off-node soundings through `Grid::insert` (prediction → corrected insert) and assert
+    the corrected node estimate is closer to ground truth than the same run with
+    correction disabled (predicted depth withheld). This proves the pipeline executes
+    and helps, not just compiles.
 
 ## Files to Change
 
 | File | Change |
 |------|--------|
-| `cube_bathymetry/src/node.cpp` | Re-enable slope correction with corrected sign; add explanatory comments |
-| `cube_bathymetry/include/cube_bathymetry/node.h` | Add `setPredictedDepth(float depth, float variance)` declaration |
-| `cube_bathymetry/test/test_node.cpp` | Add `SlopeCorrectionAppliesOffset` and `NoSlopeCorrectionWhenZero` tests |
+| `cube_bathymetry/include/cube_bathymetry/sounding.h` | Add signed `range` field + populate in `SonarDetections` ctor; doc sign convention |
+| `cube_bathymetry/include/cube_bathymetry/node.h` | Declare `setPredictedDepth`, current-estimate accessor |
+| `cube_bathymetry/src/node.cpp` | Re-enable corrected slope offset; implement `setPredictedDepth`/accessor; comments + sentinel fix |
+| `cube_bathymetry/include/cube_bathymetry/grid.h` | Declare `interpolatePredictedDepth` |
+| `cube_bathymetry/src/grid.cpp` | Implement bilinear prediction; wire into `insert` before `node->insert` |
+| `cube_bathymetry/include/cube_bathymetry/geo_grid.h` | Declare prediction helper (GeoGrid parity) |
+| `cube_bathymetry/src/geo_grid.cpp` | Prediction step in `insert` (or document split to follow-on) |
+| `cube_bathymetry/test/test_node.cpp` | Off-boresight + boresight + zero/invalid offset tests |
+| `cube_bathymetry/test/test_grid.cpp` | Interpolation unit test + end-to-end slope integration test |
 
 ## Principles Self-Check
 
 | Principle | Consideration |
 |---|---|
-| Fix it completely | The formula sign bug is fixed, the setter is added, and tests cover both the corrected and the zero-z paths. The grid-integration follow-on is called out explicitly rather than left silent. |
-| Never document from assumptions | Sign convention derived from reading `sounding.h` (header comment), `node.cpp` blunder comparisons, `original_cube/libsrc/cube/cube_node.c`, and `original_cube/libsrc/sounding/sounding.h`. |
-| Robustness | Guard conditions match the original (`z != 0.0` and `predicted_depth_ != INVALID_DATA`). |
+| Fix it completely | Both review-plan must-fixes addressed: correct slant-range analog (not `.z`) and a working prediction pipeline, not dead code. Tests hit off-boresight where the bug hid. |
+| Never document from assumptions | Offset/sign derived from `sounding.c:1268/1278`, `cube_node.c:1846`, `cube_grid.c:2360/1666`; port types read from `sounding.h`, `node.h`, `grid.cpp`, `geo_grid.cpp`, `hypothesis.h`. |
+| Robustness | Guards: `range != 0.0`, `predicted_depth_ != INVALID_DATA`, `nullopt` when 4-NN incomplete, div-by-zero guard on `|z|`. Faithful to original cold-grid behaviour. |
+| Replicate, don't invent | Prediction = port of `cube_grid_interpolate` + `cube_node_set_preddepth`; not a new scheme. Divergences (variance model, GeoGrid geometry) called out, not hidden. |
 
 ## ADR Compliance
 
 | ADR | Triggered | How addressed |
 |---|---|---|
-| None directly triggered | — | Change is a pure algorithmic re-enable within an existing file; no new topics, parameters, or architecture changes. |
+| None | No | Pure algorithmic faithful-port; no new topics/params/QoS/lifecycle. The `range` field on the internal `Sounding` struct is not a ROS message change. |
 
 ## Consequences
 
-| If we change... | Also update... | Included in plan? |
+| If we change... | Also update... | Included? |
 |---|---|---|
-| `Node::insert` slope correction | `Node::setPredictedDepth` (new, must be added) | Yes — step 2 |
-| `setPredictedDepth` API | Grid/GeoGrid callers that will eventually supply predicted surface | No — follow-on; noted as open question |
-| Slope correction enabled | Tests | Yes — step 3 |
+| `Sounding` adds `range` | both ctors (`SonarDetections` + explicit-depth) | Yes — Part A.1 |
+| `Node::insert` offset | `setPredictedDepth` accessor (new) | Yes — Part B |
+| `Grid::insert` prediction step | `GeoGrid::insert` parity | Yes — Part B.7 (or split, see scope) |
+| New offset/pipeline | `test_node.cpp` + `test_grid.cpp` | Yes — Part C |
+| Variance interpolation model | `cube_grid_est_interp_error` fidelity | Partial — port faithfully or flag simplification (Risks) |
 
 ## Open Questions
 
-- **Grid integration follow-on**: Should a new issue be filed now to track hooking
-  `setPredictedDepth` into Grid/GeoGrid after a prior-surface interpolation pass, or
-  is that left for discovery when the interpolation pipeline is built? This plan does
-  not implement the grid-level call site — slope correction will compile and have a
-  test, but will remain inactive in production until a caller sets the predicted depth.
+- [ ] **GeoGrid bilinear geometry**: regular-grid bilinear has no exact GGGS-cell analog.
+  Acceptable to port nearest-estimated-neighbour prediction for `GeoGrid` and document
+  the divergence, or must GeoGrid match `Grid` exactly before merge?
+- [ ] **PR shape**: land Part A+B(Grid)+C as one PR and stack GeoGrid parity as a
+  follow-on if it proves large, or insist on a single PR covering both grids?
+
+## Risks (honest read — this is larger than the issue implied)
+
+- **The interpolation pipeline (Part B) is the bulk of the work and the real risk.** The
+  one-line offset (Part A) is small; building faithful prior-surface prediction and
+  wiring it into two different grid representations (regular `Grid` + sparse GGGS
+  `GeoGrid`) is a non-trivial port. The original's variance-propagation
+  (`cube_grid_est_interp_error`, `cube_grid.c:2306`) is fiddly and may need its own
+  careful port or a documented simplification.
+- **Cold-grid / ordering coupling**: prediction reads already-estimated neighbours, so
+  results depend on sounding insert order until the surface fills. This matches the
+  original but makes the integration test sensitive to construction; the test must use a
+  surface that is pre-seeded or inserted in an order that exercises the corrected path
+  deterministically.
+- **Mitigation / fallback**: if GeoGrid parity balloons under the ~2-day deployment
+  pressure, the defensible minimum is Part A + Part B for `Grid` + all of Part C
+  (off-boresight correctness proven end-to-end on the regular grid), with GeoGrid parity
+  as an explicitly-filed stacked follow-on issue — **not** a silently-dead path.
 
 ## Estimated Scope
 
-Single PR. Three files changed; no new dependencies; no API surface beyond the one new
-public method. Test additions are self-contained.
+**Single PR if GeoGrid parity is tractable; otherwise a 2-PR stack** (Part A + Part B
+for `Grid` + Part C first; GeoGrid prediction parity second). This is materially larger
+than a "re-enable one block" change — it builds a prediction subsystem. The plan flags
+the split point rather than understating the size.

--- a/.agent/work-plans/issue-15/progress.md
+++ b/.agent/work-plans/issue-15/progress.md
@@ -409,3 +409,24 @@ Plan named `test_grid.cpp` for the integration test. `Grid`/`GeoGrid` keep `node
 
 **Status**: complete
 **By**: Claude Code Agent (Claude Opus)
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-21 14:51 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-15 at `156c705`
+**Mode**: pre-push
+**Depth**: Deep (reason: 226 production+test LOC ≥ 200, and correctness-sensitive CUBE depth-estimation math)
+**Must-fix**: 0 | **Suggestions**: 1
+**Round**: 1 | **Ship**: recommended — no must-fix; formula verified against `original_cube/` by two independent fresh-context passes; tests discriminate the correct formula and pass.
+
+### Findings
+- [ ] (suggestion) `setPredictedDepth(depth, variance)` callers must supply a valid variance — a real `predicted_depth_` paired with a sentinel/`INVALID_DATA` variance would make `sqrt(variance)` ~1.8e19 and neutralize the blunder limit at `node.cpp:96-99`. Latent property of the existing two-field design, now reachable via the new public setter; no current caller triggers it. Add a one-line doc note (or debug assert) — `node.cpp:263-270`, `node.h:186-203`.
+
+### Notes
+- Static analysis (ament_cpplint, ament_uncrustify) clean on all 4 changed C++ files. cppcheck flagged only untouched/pre-existing lines (`constVariableReference` at `node.cpp:241`, single-file `unusedStructMember` false positives) — dropped by the silence filter.
+- Two fresh-context adversarial passes (Lens A logic, Lens B systemic) independently re-derived `offset = predicted_depth_(node) − predicted_depth_at_touchdown` against `cube_node.c:1846` + the `mapsheet_cube.c:2434` `snd->range` overwrite and confirmed it correct (negative-down, no `1/cos²`). Sentinel correction (`INVALID_DATA` vs the old `parameters.no_data_value`=`quiet_NaN()`) confirmed faithful. Unwired producer path confirmed inert (offset 0) for both Grid and GeoGrid.
+- Plan adherence: exact — all 4 planned files changed, no scope creep; the `test_grid.cpp`→`test_node.cpp` deviation was already folded into plan v3's Files-to-Change table.
+- Reminder for the publish checkpoint: file the deferred producer follow-on (external-prior load + per-sounding touchdown interpolation) drafted in the Implementation entry, and have the PR body state plainly that slope correction stays inert (offset 0) in production until that follow-on lands.

--- a/.agent/work-plans/issue-15/progress.md
+++ b/.agent/work-plans/issue-15/progress.md
@@ -30,3 +30,32 @@ issue: 15
 
 ### Open questions
 - [ ] Grid integration follow-on: should a new issue be filed now to track hooking `setPredictedDepth` into Grid/GeoGrid after a prior-surface interpolation pass, or leave for discovery when that pipeline is built?
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-21 02:22 -0400
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-15/plan.md` at `e3129be`
+**PR**: PR-less (--issue mode)
+**Verdict**: changes-requested
+
+### Findings
+- [ ] (must-fix) Slope-correction formula uses the wrong analog field AND the wrong sign. The plan equates the port's `sonar_relative_position.z` with the original's `snd->range`, but they are different quantities. Original (`sounding.c:1268`, `sounding_hips.c`, `sounding_gsf.c:481`): `range = depth / cos(angle)` — a *slant-projected signed depth*, magnitude **larger** than `|depth|`, and **negative-down** (since the original's `depth` is "always negative internally", `sounding.h:423`). The port's `sonar_relative_position.z = slant_range * cos(tx) * cos(rx)` is the *vertical component*, magnitude equal to `|depth|` (**smaller** than the slant), and **positive-down**. They differ by the obliquity factor `1/cos²`, not just a sign flip. Worked example (rx=60°, slant s): original final depth `= snd->depth + pred_depth - range = -0.5s + pred_depth + s = pred_depth + 0.5s`; plan's port final `= snd->depth + pred_depth + z = -0.5s + pred_depth + 0.5s = pred_depth`. These disagree by `0.5s` off-boresight, so the plan's correction silently flattens to `pred_depth` instead of reproducing CUBE's slope offset. The plan's sign-table claim ("`predicted_depth_ + sonar_relative_position.z`") is internally self-consistent with its own test but does **not** reproduce the original algorithm. — `plan.md:30-50`
+- [ ] (must-fix) The plan's test (`SlopeCorrectionAppliesOffset`) only validates the plan's own (incorrect) formula, not the original CUBE behavior, so it would lock in the wrong result. A correct test must reconstruct the original `offset = pred_depth - depth/cos(angle)` for a genuinely off-boresight beam (non-zero rx/tx angle) and assert against that, otherwise the boresight-only case masks the error (at boresight both formulas coincide). — `plan.md:75-84`
+- [ ] (must-fix / decision gate) Slope correction is inert at runtime as planned. `predicted_depth_` defaults to `INVALID_DATA` (= `float::max()`, `common.h:38`), is never NaN, and **no caller anywhere sets it** (`setPredictedDepth` has zero call sites; `grid.cpp:122` / `geo_grid.cpp:95` never supply a predicted depth). So at runtime the guard `predicted_depth_ != INVALID_DATA` is always false and the re-enabled block never executes. The plan honestly scopes the Grid/GeoGrid hook-up as a follow-on (`plan.md:53-59,117,122-126`), which prevents the PR from being outright misleading — but it means this PR re-enables a path that (a) cannot run in production and (b) would compute wrong depths if it did. Recommend: get the formula right first, and decide explicitly whether to land a dead-but-tested path now (with the follow-on issue filed and referenced) or fold the grid call-site into this PR so the feature is actually exercised. — `plan.md:53-59`
+- [ ] (suggestion) Confirm `cos(tx_angle) * cos(rx_angles[i])` (the port's `z` construction, `sounding.h:50`) vs the original's single-angle `cos(angle)` (`sounding.c:1268`). The original projects with one beam angle; the port uses the product of two. Whichever field the corrected formula ends up using, the obliquity model must match the original's intent — re-derive `range`-equivalent from the port's geometry rather than reusing a field built for a different purpose. — `plan.md:25-28`
+- [ ] (suggestion) Note guard mismatch in the commented code being replaced: it references `parameters.no_data_value` (`node.cpp:118-120`) while the live blunder check uses `INVALID_DATA` (`node.cpp:93`). The plan correctly specifies `predicted_depth_ != INVALID_DATA` for the new guard — just call out that the old sentinel is being deliberately corrected. — `plan.md:66-68`
+
+### Evaluation summary
+| Dimension | Verdict | Notes |
+|---|---|---|
+| Scope | Good | 3 files, one method, self-contained; appropriate for a single PR. |
+| Issue alignment | Good | Addresses the issue's "re-enable slope correction" ask. |
+| File targeting | Good | `node.cpp`/`node.h`/`test_node.cpp` are the right files. |
+| Consequences | Needs work | The follow-on (grid call-site) is named but the runtime-inert consequence is under-weighted given the formula bug. |
+| Principle alignment | Concern | "Fix it completely" / "never document from assumptions": the sign-convention table is asserted as verified but the `range` analog is wrong on closer reading of `sounding.c:1268`. |
+| ADR compliance | Good | No ADR triggered (pure algorithmic re-enable). |
+| ROS conventions | N/A | No topics/params/QoS/lifecycle touched. |
+
+The plan is well-organized and the runtime-inert risk is disclosed, but the core slope-correction formula is incorrect (wrong analog field + wrong sign/obliquity), so implementing as written would silently corrupt off-boresight depths. Fix the formula and its test against the original `pred_depth - depth/cos(angle)` semantics before implementing; resolve the land-dead-path-vs-wire-up-grid decision explicitly.

--- a/.agent/work-plans/issue-15/progress.md
+++ b/.agent/work-plans/issue-15/progress.md
@@ -367,3 +367,45 @@ umbrella follow-on). Ready for implementation.
 - [ ] (suggestion) Prefer a default member initializer for `predicted_depth_at_touchdown` over per-ctor sets — `plan.md:132-137`
 - [ ] (recommendation) Adopt `INVALID_DATA` sentinel (not literal `0.0`); comment-cite `cube_grid.c:2383` — `plan.md:227-231`
 - [ ] (recommendation) One umbrella follow-on for the external-prior + touchdown-interpolation producer — `plan.md:232-234`
+
+## Implementation
+**Status**: complete
+**When**: 2026-06-21 10:30 -04:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Branch**: feature/issue-15
+**Commits**: `db05fc3` (production), `f5831d8` (tests), `9dd4df7` (plan sync) — atomic, agent identity, hooks passed, NOT pushed.
+
+### What changed (3 production edits + tests, per the approved v3 plan)
+- **`sounding.h`**: added `float predicted_depth_at_touchdown = INVALID_DATA;` (default member initializer, per review suggestion 2 — no per-ctor edit). Negative-down predicted-surface depth at the sounding touchdown; the port's analog of the *overwritten* `snd->range` (`mapsheet_cube.c:2434`), deliberately NOT named `range`. Doc cites `cube_grid.c:2383` for why the literal-original `0.0` sentinel is port-unsafe (a real shoreline touchdown depth can be `0.0`) and `INVALID_DATA` carries the faithful intent without the value collision (review suggestion 1 applied).
+- **`node.h` / `node.cpp`**: added `setPredictedDepth(float, float)` — a 1:1 port of `cube_node_set_preddepth` (`cube_node.c:1084`) — plus a `predictedDepth()` const accessor for the future producer + tests.
+- **`node.cpp` `Node::insert`**: re-enabled the previously-commented offset block with the corrected formula `offset = predicted_depth_ - sounding.predicted_depth_at_touchdown`, queued as `sounding.depth + offset`. Guard reproduces the original `range != 0.0 && pred_depth != no_data_value`, both sentinels as `INVALID_DATA` (the old comment's `parameters.no_data_value` was `quiet_NaN()` — doubly wrong; corrected). Comment block cites `cube_node.c:1846` + `mapsheet_cube.c:2434`, states why it was disabled at port time (no predicted-surface field), and that no `1/cos^2` obliquity applies.
+- **Producer NOT built** (deferred follow-on): nothing sets `predicted_depth_` or `predicted_depth_at_touchdown` in production, so both stay at `INVALID_DATA` => offset 0 => unchanged correct-but-uncorrected behaviour for both `Grid` and `GeoGrid`.
+
+### Tests (`test_node.cpp`, +4)
+- `SlopeCorrectionSurfaceSlopeDelta` — synthetic-injection end-to-end (seed `setPredictedDepth(-10.0)` + touchdown `-10.6`, raw depth `-10.5`; drive insert→queueFlush→extractDepthAndUncertainty; assert converged `-9.9` reconstructed **independently** from `depth + (pred_node - pred_touchdown)`, and that it does NOT collapse to `pred_node` or raw depth — so an offset-0 regression fails). Review suggestion 1 (independent reconstruction) applied.
+- `SlopeCorrectionZeroOnFlatSurface` — `pred_touchdown == pred_node` => offset 0.
+- `NoSlopeCorrectionWhenTouchdownSentinel` — sounding's touchdown is `INVALID_DATA` => offset 0.
+- `NoSlopeCorrectionWhenPredictedDepthInvalid` — node has no prediction (default `INVALID_DATA`) => offset 0 (the production-unwired path).
+
+### Deviation from plan (recorded in plan.md `9dd4df7`)
+Plan named `test_grid.cpp` for the integration test. `Grid`/`GeoGrid` keep `nodes_` private with **no per-node seed API**, so `predicted_depth_` cannot be set through the grid public surface. The end-to-end synthetic-injection test therefore lives at the **`Node`** level — the shared integration point both `Grid::insert` and `GeoGrid::insert` call (`grid.cpp:122`, `geo_grid.cpp:95`) — driving the identical pipeline. Adding a node-seed grid accessor is the deferred producer's concern, not this PR's. No `test_grid.cpp` change.
+
+### Build + test results
+- Build: **clean** (`cube_bathymetry` built; the only stderr is pre-existing GDAL `-Wunused-result` warnings in `bag_to_geotiff.cpp`, unrelated to this change).
+- gtest: **269 tests, 0 errors, 0 failures, 38 skipped** across the package. `test_node.gtest.xml`: **16 tests (was 12, +4 new slope tests), 0 failures, 0 errors** — all 4 new slope tests `result="completed"`. `test_grid.gtest.xml`: 9, 0/0. No uncrustify local-drift noise this run (uncrustify.xunit.xml: 38, 0 failures). Judged green by gtest XML.
+
+### Suggested producer follow-on issue (for the host to file at the publish checkpoint)
+**Title**: Port the CUBE predicted-surface producer (external-prior load + per-sounding touchdown interpolation) to make slope correction active
+
+**Body** (suggested):
+> Part of #15. Issue #15 ported the node-level slope-correction math (`Node::setPredictedDepth` + the corrected offset in `Node::insert`) but explicitly deferred the predicted-surface *producer* that drives it. With no producer, `predicted_depth_`/`Sounding::predicted_depth_at_touchdown` stay at `INVALID_DATA` so the offset is 0 (correct-but-uncorrected) in production.
+>
+> This issue ports the producer subsystem the port wholly lacks, as one umbrella (the two pieces only deliver value together):
+> 1. **External-prior load** (`cube_grid_initialise` analog, `cube_grid.c:1665,1712,1730`): load a prior bathymetry array, seed each node's `predicted_depth_`/variance via `setPredictedDepth`, and seed a base null hypothesis.
+> 2. **Per-sounding touchdown interpolation** (`cube_grid_interpolate` + the `mapsheet_cube.c:2434` `range` overwrite): bilinearly blend the 4 surrounding nodes' `predicted_depth_` at each sounding's touchdown `(de,dn)` and set `Sounding::predicted_depth_at_touchdown` (returns no-correction sentinel if any corner is no-data).
+>
+> The Grid-vs-GeoGrid interpolation geometry decision (regular bilinear vs the GGGS-cell analog) belongs here, with a per-node seed API on `Grid`/`GeoGrid`. Once landed, slope correction is active end-to-end; until then, deployed behaviour remains uncorrected (#15 is honest about this).
+
+**Status**: complete
+**By**: Claude Code Agent (Claude Opus)

--- a/.agent/work-plans/issue-15/progress.md
+++ b/.agent/work-plans/issue-15/progress.md
@@ -240,3 +240,130 @@ review.
 - [ ] Follow-on shape: one umbrella issue for external-prior load + touchdown interpolation
   + Grid/GeoGrid geometry, or split prior-load from interpolation. (Recommend one umbrella —
   they only deliver value together.)
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-21 10:05 -04:00
+**By**: Claude Code Agent (Claude Opus)  <!-- independent fresh-context dispatch (#490); not the plan author's self-review -->
+
+**Plan**: `.agent/work-plans/issue-15/plan.md` at `7abd050`
+**PR**: PR-less (--issue mode)
+**Verdict**: approve-with-suggestions
+
+This is the **third** plan review. v1 was changes-requested (used the vertical `.z`
+component — an obliquity error). v2 was changes-requested (used `depth/cos(angle)` plus a
+self-bootstrap-from-running-estimates path that does not exist in the original). v3 was
+re-verified line-by-line against `original_cube/` for this review; **every load-bearing
+claim holds**, and the formula is finally correct.
+
+### Source verification (independently re-read, not assumed)
+
+| v3 claim | Source | Result |
+|---|---|---|
+| Offset site `offset = node->pred_depth − snd->range`, queued `snd->depth+offset` | `cube_node.c:1846,1847,1864` | ✓ verbatim |
+| `snd->range` OVERWRITTEN before insert with interpolated touchdown pred_depth | `mapsheet_cube.c:2418-2444` (comment + `data[snd].range = cube_grid_interpolate(...de,dn...)`) | ✓ verbatim |
+| Interpolation is at TOUCHDOWN `(de,dn)` from sounding east/north, not the node | `mapsheet_cube.c:2426,2434-2435` | ✓ |
+| `cube_grid_interpolate` bilinearly blends 4 corners' `pred_depth`, returns `0.0f` if any corner no-data | `cube_grid.c:2360,2374-2395,2379-2384` | ✓ |
+| `depth/cos(angle)` is the *error-model* range, computed at file-load while depth still positive, negated after — a different quantity, overwritten before the offset runs | `sounding.c:1268,1280` | ✓ irrelevant at offset site; **no `1/cos²`** |
+| `cube_grid_insert_depths` never interpolates / never sets pred_depth — only calls `cube_node_insert` (NO self-bootstrap) | `cube_grid.c:1877-1992` (only `cube_node_insert` at :1981) | ✓ — v1/v2's invented path confirmed absent |
+| `pred_depth` seeded ONLY from external prior array via `cube_grid_initialise` + base-hypothesis | `cube_grid.c:1665,1712,1730` | ✓ |
+| `cube_node_set_preddepth` is a trivial 1:1 setter; doc: INVALID ⇒ no slope correction, NaN ⇒ don't incorporate | `cube_node.c:1066-1093` | ✓ |
+| Port `predicted_depth_` is negative-down, blunder-checked vs `sounding.depth`, defaults `INVALID_DATA`, set NOWHERE | `node.cpp:93-104`, `node.h:198,202`, `common.h:38` | ✓ — confirmed inert |
+| Port has no `Sounding.range`; `.z` (`sonar_relative_position.z = range*cos(tx)*cos(rx)`) is the v1 vertical-component trap | `sounding.h:50,33-73` | ✓ — new field correctly named `predicted_depth_at_touchdown`, NOT `range` |
+| Commented block's stale `parameters.no_data_value` sentinel vs live `INVALID_DATA` guard | `node.cpp:118` vs `node.cpp:93`; `parameters.h:81` (`no_data_value = quiet_NaN()`) | ✓ — the old sentinel was doubly wrong (NaN, not the live `INVALID_DATA`); plan's correction is right |
+| Both `Grid::insert` and `GeoGrid::insert` call the SAME `Node::insert` and supply no predicted depth | `grid.cpp:122`, `geo_grid.cpp:95` | ✓ — offset-0 safety identical for dense Grid and sparse GeoGrid |
+
+### Findings
+
+- [ ] (suggestion) **Off-boresight test discrimination — tighten the framing.** The corrected
+  offset is **angle-independent**: it depends only on `predicted_depth_` (node) and the
+  `Sounding.predicted_depth_at_touchdown` field, NOT on beam geometry. So the real
+  discriminator against the two prior wrong formulas is *touchdown-position* offset along a
+  known synthetic prior surface, not *beam angle*. The plan's `SlopeCorrectionSurfaceSlopeDelta`
+  (`pred_node=-10`, `pred_touchdown=-10.6`, `depth=-10.5` ⇒ expect `-10.1`) does discriminate —
+  v1 (`.z`) and v2 (`depth/cos`) both depend on beam angle and cannot hit `depth + (pred_node −
+  pred_touchdown)` for a genuinely off-node touchdown — **provided the test reconstructs the
+  expected value independently from `pred_node − pred_touchdown` (the plan says it will) and does
+  NOT echo the implementation**. Just ensure the test prose/asserts key off touchdown *position*,
+  not "off-boresight beam angle"; the plan slightly conflates the two (`plan.md:159,170-171`). —
+  `plan.md:164-185`
+
+- [ ] (suggestion) **`Sounding` default-member-init suffices; "set in both ctors" is redundant.**
+  Both ctors (`sounding.h:35-38,40-59`) only set `depth`; a default member initializer
+  `float predicted_depth_at_touchdown = INVALID_DATA;` covers both with no per-ctor edit. The
+  plan's "set sentinel in both ctors" (`plan.md:137,191`) is harmless but unnecessary — prefer the
+  default initializer (matches how `depth`/`intensity` already default). — `plan.md:132-137`
+
+### Open-question recommendations
+
+- **Sentinel for `predicted_depth_at_touchdown`: use `INVALID_DATA`, NOT the literal `0.0`.**
+  In the original, `range == 0.0` is the no-correction sentinel only because
+  `cube_grid_interpolate` *returns `0.0f`* on no-data corners (`cube_grid.c:2383`) — `0.0` is an
+  artifact of that return convention, not a deliberate semantic choice, and is safe there only
+  because a real seabed `pred_depth` is never exactly `0.0` m. In the port a legitimately
+  interpolated touchdown depth at the shoreline could be `0.0`, which a literal `!= 0.0` guard
+  would wrongly skip. `INVALID_DATA` is the faithful-*intent* port ("no interpolation result ⇒
+  skip") without the value collision. Recommend the plan adopt `INVALID_DATA` (it already prefers
+  this) and add a one-line comment citing `cube_grid.c:2383` so the deviation from the literal
+  `0.0` is documented as intentional, not accidental.
+- **Follow-on shape: one umbrella issue.** External-prior load (`cube_grid_initialise` analog)
+  and per-sounding touchdown interpolation (`cube_grid_interpolate` + the `mapsheet_cube.c` range
+  overwrite) only deliver value together — neither is useful alone — and the Grid-vs-GeoGrid
+  geometry decision belongs to the same producer subsystem. Agree with the plan: one umbrella
+  issue. File it before/with the PR and reference it.
+
+### Producer-deferral judgment (faithful increment vs inert-path-in-disguise)
+
+**This is a faithful, safe increment — not a re-skinned inert-path defect.** Three reasons the
+v2 inert-path objection does not recur here:
+
+1. **The math being landed is now CORRECT**, where v1/v2 landed a *wrong* formula behind the
+   inert guard. v2's defect was "re-enables a path that, if it ran, would corrupt off-boresight
+   depths." v3's path, if it runs, computes the verified `pred_depth(node) − pred_depth(touchdown)`.
+   Landing a correct-but-dormant primitive is categorically different from landing a wrong one.
+2. **The deferred piece is a genuinely separate subsystem**, not a call-site bolt-on. The producer
+   is the entire external-prior pipeline: a prior-bathymetry loader (`cube_grid_initialise`:
+   load array, seed `pred_depth` + base hypothesis per node) plus per-sounding touchdown
+   interpolation (`cube_grid_interpolate` + the `mapsheet_cube.c` `range` overwrite). That is real,
+   sizeable infrastructure the port wholly lacks — deferring it is honest scoping, not a dodge.
+3. **The path is exercised, not silently-dead.** The integration test
+   (`SlopeCorrectionAppliesOnSeededSurface`) seeds `setPredictedDepth` directly and supplies a
+   synthetic `predicted_depth_at_touchdown`, driving the offset end-to-end; the paired cold-grid
+   case proves offset-0. So the block has live test coverage at exactly the cases the prior bugs hid.
+
+**Offset-0-when-unwired is safe for BOTH grids.** `Grid` and `GeoGrid` share the identical
+`Node::insert` (grid.cpp:122 / geo_grid.cpp:95) with the same default-sentinel `predicted_depth_`;
+there is no separate sparse-GeoGrid node path that could diverge. With no producer, both run at
+offset 0 — the defined correct-but-uncorrected behaviour they have today, not a regression.
+
+The one residual reservation (a suggestion, not a blocker): once merged, production CUBE still does
+**no** slope correction until the follow-on lands, so the issue's user-visible "slope correction is
+disabled" symptom persists in deployed behaviour. The plan is explicit and honest about this, files
+the follow-on, and the PR description must say so plainly so a reader doesn't mistake "re-enabled"
+for "active in production." With that framing, the increment is the right call under the Quality
+Standard's "fix it completely at the achievable boundary."
+
+### Evaluation summary
+| Dimension | Verdict | Notes |
+|---|---|---|
+| Scope | Good | 3 small production edits + focused tests; prediction subsystem correctly out-of-scope and tracked. |
+| Issue alignment | Good | Re-enables the offset with the correct algorithm; remaining production-activation gap honestly scoped + filed. |
+| File targeting | Good | `sounding.h`/`node.{h,cpp}`/`test_node.cpp`/`test_grid.cpp` are exactly right; no `grid.cpp`/`geo_grid.cpp` churn (no producer). |
+| Consequences | Good | Both ctors, `setPredictedDepth` primitive, tests, and the follow-on dependency are all captured. |
+| Principle alignment | Good | "Replicate don't invent" (formula + primitive are 1:1 ports; the rejected self-bootstrap is explicitly NOT implemented); "never document from assumptions" (every claim cited and re-verified here); "fix it completely at the achievable boundary." |
+| ADR compliance | Good | No ADR triggered — pure algorithmic faithful-port; `predicted_depth_at_touchdown` is an internal field, not a ROS message change. |
+| ROS conventions | N/A | No topics/params/QoS/lifecycle touched. |
+
+The slope-correction formula is **finally correct**: `offset = predicted_depth_(node) −
+predicted_depth_at_touchdown`, both negative-down predicted-surface depths, with no obliquity
+factor — exactly the original's `node->pred_depth − snd->range` once you account for the
+`mapsheet_cube.c:2434` overwrite. The producer deferral is a faithful, tested, safe increment, not
+the v2 inert-path problem renamed. Approve with two minor suggestions (test-framing precision,
+default-member-init) and the two open-question recommendations above (use `INVALID_DATA`; one
+umbrella follow-on). Ready for implementation.
+
+### Findings checklist (for downstream parsers)
+- [ ] (suggestion) Tighten off-boresight test framing to touchdown-position, reconstruct expected independently — `plan.md:164-185`
+- [ ] (suggestion) Prefer a default member initializer for `predicted_depth_at_touchdown` over per-ctor sets — `plan.md:132-137`
+- [ ] (recommendation) Adopt `INVALID_DATA` sentinel (not literal `0.0`); comment-cite `cube_grid.c:2383` — `plan.md:227-231`
+- [ ] (recommendation) One umbrella follow-on for the external-prior + touchdown-interpolation producer — `plan.md:232-234`

--- a/.agent/work-plans/issue-15/progress.md
+++ b/.agent/work-plans/issue-15/progress.md
@@ -74,3 +74,114 @@ This re-plan addresses both `## Plan Review` must-fixes: (1) the offset now reco
 ### Open questions
 - [ ] GeoGrid bilinear geometry has no exact GGGS-cell analog: port nearest-estimated-neighbour prediction for GeoGrid + document the divergence, or require exact parity with the regular Grid before merge?
 - [ ] PR shape: land Part A + Part B(Grid) + Part C as one PR with GeoGrid parity as a stacked follow-on if it balloons, or insist on a single PR covering both grids?
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-21 03:05 -04:00
+**By**: Claude Code Agent (Claude Opus)  <!-- independent fresh-context dispatch (#490); not the plan author's self-review -->
+
+**Plan**: `.agent/work-plans/issue-15/plan.md` at `560b52a`
+**PR**: PR-less (--issue mode)
+**Verdict**: changes-requested
+
+This is the **second** plan review (re-plan after the first was changes-requested). The v2
+plan correctly diagnoses the prior `.z`-vs-slant-range bug and the runtime-inert defect,
+and the **scope-honesty, risk section, and interpolation 4-NN/guard description are good**.
+But independent re-derivation from the original source shows the v2 plan **still has the
+slope-correction geometry wrong** — for a deeper reason than v1 — and **mis-ports the
+prediction pipeline**. Both prior reviewers (v1 author, v1 Opus reviewer) and this plan all
+misread what `snd->range` *is* at the offset site. Verified line-by-line below.
+
+### Findings
+
+- [ ] (must-fix) **`snd->range` is OVERWRITTEN before the offset runs — it is NOT
+  `depth/cos(angle)` at the slope-correction site.** The `range = depth/cos(angle)` value
+  (`sounding.c:1268`, `sounding_gsf.c:481`, `sounding_hips.c:1263`) is only the
+  *error-model* range. In the slope-correction path, `mapsheet_cube.c:2424-2444` explicitly
+  does `data[snd].range = cube_grid_interpolate(... de, dn ...)` — the comment reads
+  *"fill the result into the 'range' element of the sounding [bad! <smack>] for
+  cube_node_insert() to use for slope corrections."* So at `cube_node.c:1847`,
+  `offset = node->pred_depth − snd->range` is **`pred_depth_node − pred_depth_interpolated_at_touchdown`**:
+  the difference of two negative-down predicted-surface depths (node vs touchdown point),
+  i.e. the predicted slope between them. The plan's Part A formula
+  (`range_analog = sounding.depth / cos(angle)`, `plan.md:74-96,102-115`) reconstructs the
+  *error-model* range, which is the wrong quantity. Verified numerically: with the plan's own
+  worked example (rx=60°, depth=−9, pred=−10) the plan queues `−1 m`; the literal original
+  error-model range queues `−37 m`; the *actual* slope-corrected value is a small slope
+  delta near `−9 m`. The plan's "reproduces CUBE off-boresight" claim (`plan.md:87-93`) is
+  not borne out. — `plan.md:74-115`
+
+- [ ] (must-fix) **Part B is not a faithful port — it invents a self-bootstrap path the
+  original does not have, and assigns the interpolation to the wrong point.** The original's
+  insert path (`cube_grid_insert_depths`, `cube_grid.c:1877-1990`) never calls
+  `cube_grid_interpolate` or `set_preddepth`; it only iterates nodes and calls
+  `cube_node_insert`. `pred_depth` is set in exactly two places: the **external-prior**
+  init (`cube_grid_initialise`/`init_unct`, `cube_grid.c:1712,1812`) from a supplied prior
+  bathymetry array, and the per-sounding `range` overwrite in `mapsheet_cube.c` (above).
+  There is **no "interpolate from current running estimates during insert" mechanism** —
+  the plan's claim that `cube_grid_interpolate` "needs no external prior file … is the
+  production-relevant path" (`plan.md:117-120`) is incorrect: that routine interpolates the
+  *prior-surface* `pred_depth`, and is invoked at surface-finalization, interpolated at the
+  **sounding touchdown** `(de,dn)`, not at the node. The plan interpolates at the **node
+  position** from neighbours' running estimates (`plan.md:127-129,140-141`) — wrong source
+  field and wrong location. As written, Part B builds a new, unfaithful estimator and labels
+  it a port. — `plan.md:117-152,194-198`
+
+- [ ] (must-fix) **`predicted_depth_` must be seeded from a prior surface for the original's
+  slope correction to be meaningful at all.** The original applies slope correction only when
+  a prior bathymetry was loaded via `cube_grid_initialise` (which also seeds a base
+  hypothesis, `cube_node_add_null_hypothesis`). The port has `Hypothesis::generateNullHypothesis`
+  (`plan.md:57`) but no prior-load entry point, and `Grid::insert`/`GeoGrid::insert` never
+  set `predicted_depth_` (confirmed: `grid.cpp:122`, `geo_grid.cpp:95` — no pred set). The
+  honest faithful-port options are: (a) port `cube_grid_initialise` (external-prior load +
+  base-hypothesis seed) and the `mapsheet_cube.c` per-sounding touchdown-interpolation
+  `range` overwrite, or (b) explicitly decide the port will *not* support slope correction
+  until a prior-surface subsystem exists, and keep the block disabled with a referenced
+  follow-on. The current plan's middle path (self-bootstrap from estimates) is neither
+  faithful nor clearly-scoped. — `plan.md:32-41,117-145`
+
+- [ ] (suggestion) The Part C tests assert against the plan's own (incorrect) reconstruction
+  `pred − depth/cos(angle)` (`plan.md:156-164`). Like the v1 test, they would lock in the
+  wrong formula. Any test must assert against the *touchdown-vs-node predicted-surface
+  difference* (`pred_node − pred_touchdown`), reconstructed independently in the test from a
+  known synthetic prior surface — otherwise off-boresight passes for the wrong reason. —
+  `plan.md:156-164`
+
+- [ ] (suggestion) `INVALID_DATA`-vs-`no_data_value` sentinel correction (`plan.md:115`) and
+  the `|z|>0` div-guard are fine and worth keeping regardless of the formula rework. The
+  comment-history note (why it was disabled at port time) is good practice. — `plan.md:111-115`
+
+### Open-question recommendations (the two the plan defers)
+
+- **GeoGrid now vs follow-on**: Recommend **defer GeoGrid entirely** to a tracked follow-on
+  regardless — but only *after* the Grid-side geometry is corrected. A Grid-only landing is
+  acceptable *only* if GeoGrid is not a silently-dead path. It currently isn't dead: both
+  grids today run with offset 0 (no correction), which is a defined, safe behaviour. So
+  shipping Grid-only correction + filing a GeoGrid issue leaves GeoGrid working-without-
+  correction (acceptable, tracked), not broken. Do **not** attempt GGGS bilinear in this PR.
+- **PR shape**: Recommend the plan be **re-scoped before any implementation**, not split as-is.
+  The blocking problem is *correctness of the offset and the prediction source*, which Part A
+  and Part B share. A 2-PR stack of a wrong formula is still wrong. Sequence: (1) re-derive
+  the offset as `pred_depth_node − pred_depth_at_touchdown` from a seeded prior surface;
+  (2) decide whether this PR ports the external-prior load path (`cube_grid_initialise`) or
+  defers slope-correction-active behaviour behind a referenced follow-on; (3) only then split
+  GeoGrid off.
+
+### Evaluation summary
+| Dimension | Verdict | Notes |
+|---|---|---|
+| Scope | Needs work | Honestly sized and risk-flagged, but built on a wrong correction model; re-scope before implementing. |
+| Issue alignment | Good | Targets the issue's "re-enable slope correction" ask. |
+| File targeting | Good | `sounding.h`/`node.*`/`grid.*`/`geo_grid.*`/tests are the right files. |
+| Consequences | Needs work | Consequences table is complete *for the planned (incorrect) design*; misses the external-prior / touchdown-interpolation dependency. |
+| Principle alignment | Concern | "Never document from assumptions" / "Replicate, don't invent": the `range` semantics and the insert-time interpolation are asserted as verified-from-source but contradict `cube_grid_insert_depths`, `mapsheet_cube.c:2424`, and `cube_grid_initialise`. |
+| ADR compliance | Good | No ADR triggered (algorithmic faithful-port). |
+| ROS conventions | N/A | No topics/params/QoS/lifecycle touched. |
+
+The v2 plan is well-written and improves on v1's disclosure and risk-honesty, but the corrected
+formula does **not** hold up: `snd->range` at the offset site is the interpolated predicted
+depth at touchdown (overwritten in `mapsheet_cube.c`), not `depth/cos(angle)`, so the real
+correction is `pred_depth_node − pred_depth_touchdown`. Part B mis-ports the prediction pipeline
+(self-bootstrap from running estimates ≠ the original's external-prior + touchdown-interpolation).
+Re-derive the offset and the prediction source from `mapsheet_cube.c:2424` + `cube_grid_initialise`
+before implementation; defer GeoGrid to a tracked follow-on once Grid is correct.

--- a/.agent/work-plans/issue-15/progress.md
+++ b/.agent/work-plans/issue-15/progress.md
@@ -18,3 +18,15 @@ issue: 15
 - [ ] Add test in `test_node.cpp` covering the slope-correction path (non-zero `sonar_relative_position.z` with valid `predicted_depth_`).
 - [ ] Add comment near the re-enabled code block explaining why slope correction was originally commented out (missing `range` field at port time).
 - [ ] If a new `range` field is added to `Sounding` instead of reusing `sonar_relative_position.z`, update all `Sounding` constructors and document the field's sign convention.
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-21 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Plan**: `.agent/work-plans/issue-15/plan.md` at `e3129be`
+**Branch**: feature/issue-15 at `e3129be`
+**Phases**: single
+
+### Open questions
+- [ ] Grid integration follow-on: should a new issue be filed now to track hooking `setPredictedDepth` into Grid/GeoGrid after a prior-surface interpolation pass, or leave for discovery when that pipeline is built?

--- a/.agent/work-plans/issue-15/progress.md
+++ b/.agent/work-plans/issue-15/progress.md
@@ -1,0 +1,20 @@
+---
+issue: 15
+---
+
+# Issue #15 — Slope correction is disabled (commented out) in Node::insert
+
+## Issue Review
+**Status**: complete
+**When**: 2026-06-21 00:00 +00:00
+**By**: Claude Code Agent (Claude Sonnet)
+
+**Issue**: #15
+**Comment**: https://github.com/rolker/cube_bathymetry/issues/15#issuecomment-4761051413
+**Scope verdict**: well-scoped
+
+### Actions
+- [ ] Verify sign convention of `sonar_relative_position.z` matches `predicted_depth_` before implementing offset (`predicted_depth_ - sonar_relative_position.z`); sonar frame z is "down" while depth convention is "negative below surface".
+- [ ] Add test in `test_node.cpp` covering the slope-correction path (non-zero `sonar_relative_position.z` with valid `predicted_depth_`).
+- [ ] Add comment near the re-enabled code block explaining why slope correction was originally commented out (missing `range` field at port time).
+- [ ] If a new `range` field is added to `Sounding` instead of reusing `sonar_relative_position.z`, update all `Sounding` constructors and document the field's sign convention.

--- a/.agent/work-plans/issue-15/progress.md
+++ b/.agent/work-plans/issue-15/progress.md
@@ -185,3 +185,58 @@ correction is `pred_depth_node − pred_depth_touchdown`. Part B mis-ports the p
 (self-bootstrap from running estimates ≠ the original's external-prior + touchdown-interpolation).
 Re-derive the offset and the prediction source from `mapsheet_cube.c:2424` + `cube_grid_initialise`
 before implementation; defer GeoGrid to a tracked follow-on once Grid is correct.
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-21 09:30 -04:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-15/plan.md` (v3 — REPLACES the v2 plan in full)
+**Branch**: feature/issue-15
+**Phases**: single small PR (node-level math + primitive + tests); prior-surface subsystem is a referenced follow-on
+
+This is the **third** plan, re-authored after the round-2 changes-requested pinned the
+correct algorithm. Every claim in v3 was re-verified line-by-line against `original_cube/`
+before writing (see plan's Verification table):
+
+- **Offset corrected** to the predicted-SURFACE slope delta `offset = pred_depth(node) −
+  pred_depth(touchdown)`. Confirmed `snd->range` is OVERWRITTEN at `mapsheet_cube.c:2434`
+  with `cube_grid_interpolate(... de, dn ...)` (the bilinear interpolation of the 4
+  surrounding nodes' `pred_depth` at the touchdown point), so the `depth/cos(angle)`
+  error-model range (`sounding.c:1268`) is irrelevant at the offset site. No `1/cos²`
+  obliquity factor — both terms are same-convention negative-down predicted depths.
+- **No self-bootstrap.** Confirmed `cube_grid_insert_depths` (`cube_grid.c:1877-1992`)
+  never sets `pred_depth` / never interpolates — it only calls `cube_node_insert`.
+  `pred_depth` is seeded from an EXTERNAL prior via `cube_grid_initialise`
+  (`cube_grid.c:1665,1712`) + base hypothesis (`:1730`). Both prior plans invented the
+  interpolate-from-running-estimates path; it does not exist in the original.
+
+**Crux resolution**: the port has **no** predicted-surface mechanism (no prior-load, no
+`setPredictedDepth`, no `Sounding.range`; `predicted_depth_` is `INVALID_DATA` everywhere
+and nothing sets it). A faithful *active* correction needs the whole `cube_grid_initialise`
++ touchdown-interpolation subsystem — too large to port correctly now. v3 therefore ports
+the node-level math **faithfully and correctly** (corrected offset + a 1:1
+`cube_node_set_preddepth` port) and **explicitly defers** active correction behind the
+external-prior subsystem, FILED as a referenced follow-on. With no producer wired,
+`predicted_depth_at_touchdown` stays at its sentinel → offset 0 → the defined,
+correct-but-uncorrected behaviour the grids have today. The block is exercised end-to-end
+by an integration test that supplies a synthetic prediction directly, so it is neither
+non-physical nor silently-dead — it activates the instant a prior surface is supplied.
+
+**Scope**: Grid-only per the review; in fact neither grid is wired to a producer in this
+PR, so both run at offset 0 unchanged. GeoGrid (and the GGGS bilinear-vs-regular geometry
+question) belongs to the prior-surface follow-on. Field named `predicted_depth_at_touchdown`
+(NOT `range`) to avoid resurrecting the misread.
+
+**Size/risk after this third pass**: low. 3 production edits + focused tests; the large,
+risky prediction subsystem is correctly out-of-scope and tracked. Remaining open question
+is the no-correction sentinel choice (`INVALID_DATA` vs literal-original `0.0`), settled at
+review.
+
+### Open questions
+- [ ] Sentinel for `predicted_depth_at_touchdown`: `INVALID_DATA` (preferred — a real
+  interpolated touchdown depth could legitimately be `0.0`) vs the literal original
+  `range != 0.0` test. Flagged for review.
+- [ ] Follow-on shape: one umbrella issue for external-prior load + touchdown interpolation
+  + Grid/GeoGrid geometry, or split prior-load from interpolation. (Recommend one umbrella —
+  they only deliver value together.)

--- a/.agent/work-plans/issue-15/progress.md
+++ b/.agent/work-plans/issue-15/progress.md
@@ -59,3 +59,18 @@ issue: 15
 | ROS conventions | N/A | No topics/params/QoS/lifecycle touched. |
 
 The plan is well-organized and the runtime-inert risk is disclosed, but the core slope-correction formula is incorrect (wrong analog field + wrong sign/obliquity), so implementing as written would silently corrupt off-boresight depths. Fix the formula and its test against the original `pred_depth - depth/cos(angle)` semantics before implementing; resolve the land-dead-path-vs-wire-up-grid decision explicitly.
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-21 02:41 -04:00
+**By**: Claude Code Agent (Claude Opus)
+
+**Plan**: `.agent/work-plans/issue-15/plan.md` at `560b52a` (re-plan, expanded scope — REPLACES the prior plan)
+**Branch**: feature/issue-15 at `560b52a`
+**Phases**: single PR if GeoGrid parity is tractable, else a 2-PR stack (Grid core first, GeoGrid prediction parity second)
+
+This re-plan addresses both `## Plan Review` must-fixes: (1) the offset now reconstructs the original's slant-projected signed-depth analog `range = depth/cos(angle)` (via `depth * slant / |z|`) instead of the vertical `.z` component, with tests at off-boresight angles where the prior bug hid; (2) it builds the prior-surface prediction pipeline (faithful port of `cube_grid_interpolate` + `cube_node_set_preddepth`) and wires `setPredictedDepth` into `Grid::insert` (and `GeoGrid::insert`) so slope correction runs end-to-end rather than as dead code.
+
+### Open questions
+- [ ] GeoGrid bilinear geometry has no exact GGGS-cell analog: port nearest-estimated-neighbour prediction for GeoGrid + document the divergence, or require exact parity with the regular Grid before merge?
+- [ ] PR shape: land Part A + Part B(Grid) + Part C as one PR with GeoGrid parity as a stacked follow-on if it balloons, or insist on a single PR covering both grids?

--- a/.agent/work-plans/issue-15/progress.md
+++ b/.agent/work-plans/issue-15/progress.md
@@ -430,3 +430,37 @@ Plan named `test_grid.cpp` for the integration test. `Grid`/`GeoGrid` keep `node
 - Two fresh-context adversarial passes (Lens A logic, Lens B systemic) independently re-derived `offset = predicted_depth_(node) − predicted_depth_at_touchdown` against `cube_node.c:1846` + the `mapsheet_cube.c:2434` `snd->range` overwrite and confirmed it correct (negative-down, no `1/cos²`). Sentinel correction (`INVALID_DATA` vs the old `parameters.no_data_value`=`quiet_NaN()`) confirmed faithful. Unwired producer path confirmed inert (offset 0) for both Grid and GeoGrid.
 - Plan adherence: exact — all 4 planned files changed, no scope creep; the `test_grid.cpp`→`test_node.cpp` deviation was already folded into plan v3's Files-to-Change table.
 - Reminder for the publish checkpoint: file the deferred producer follow-on (external-prior load + per-sounding touchdown interpolation) drafted in the Implementation entry, and have the PR body state plainly that slope correction stays inert (offset 0) in production until that follow-on lands.
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-21 15:47 +00:00
+**By**: Claude Code Agent (Claude Opus)
+**Verdict**: approved
+
+**Branch**: feature/issue-15 at `abec6cb` (merge commit — `origin/jazzy` merged into the branch)
+**Mode**: pre-push (RE-REVIEW after merge)
+**Depth**: Deep (reason: merge union of three branches — #15/#54/#57 — over correctness-sensitive CUBE core)
+**Must-fix**: 0 | **Suggestions**: 2
+**Round**: 2 | **Ship**: recommended — no must-fix; merge is a provably clean additive union (zero-line diff on all #54/#57 files), suite green, composition independently confirmed.
+
+This is Round 2: a re-review of the **merge union**, not the slope math (Round 1 already approved the
+math against `original_cube/`). Since Round 1, `origin/jazzy` advanced with #54 (backscatter
+co-estimation, ADR-0007) and #57 (bathy-store epoch importer); both touched the same CUBE core files
+and were merged into the branch at `abec6cb`. `origin/jazzy` (= `def09d3`) fetched offline → diffed
+against the local ref per SKILL fallback. Round-1's lone suggestion (variance guard on
+`setPredictedDepth`) is now resolved in `node.cpp:364-367` (commit `1367f0c`).
+
+### Findings
+- [ ] (suggestion) `extractNodeRecord` comment is merge-stale: "Slope is gated on cube_bathymetry#15 (disabled today in Node::insert). Until #15 lands…" — #15 has landed and the slope block IS re-enabled in `Node::insert`; it is merely inert (offset 0) until the predicted-surface **producer** follow-on. Reword so a reader doesn't conclude slope is still fully disabled / #15 unmerged. Behavior (identity GeoCoder correction) still correct, so suggestion-only — `src/node.cpp:268-269`.
+- [ ] (suggestion, separate/pre-existing — not introduced by this merge) The "no caller depends on `sizeof(DepthAndUncertainty)`" contract is comment-guarded only; a `static_assert(sizeof(...)==16)` would enforce the `#pragma pack` layout — `include/cube_bathymetry/common.h:88-90`.
+
+### Merge-union verification (the focus)
+- **Combined `Node::insert` composes correctly and independently.** jazzy(#54) already wired `queueEstimate(sounding.depth + offset, …, sounding.intensity, sounding.beam_angle)` with `offset` pinned to `0.0`; #15's net change only makes `offset` non-zero (`node.cpp:162-166`). Offset adds to the depth arg ONLY; intensity/beam_angle pass verbatim. Co-estimation (`recordBeam`) sees the slope-CORRECTED depth — correct per ADR-0007 D2 ("intensity rides the winning depth"): the corrected depth is the same beam projected onto the node, intensity is its passenger. All early-returns drop depth+intensity together (no desync vs jazzy).
+- **`Sounding`**: HEAD = jazzy field set + the single new `predicted_depth_at_touchdown` (`sounding.h:107`). One each of `intensity`/`beam_angle`/`predicted_depth_at_touchdown`; nothing dropped/duplicated.
+- **`test_node.cpp`**: 24 `TEST_F` = 12 original + 4 SlopeCorrection (#15) + 8 backscatter (#54); braces 49/49. `test_node.gtest.xml`: 24 tests, 0 failures, 0 errors. Full package gtest: 105 tests, 0/0 across 10 suites (incl. #57 `test_store_import` 3/0/0). All 8 lint xunit reports 0 failures. (The brief's "300" aggregates per-file lint cases.)
+- **No reversion of #54/#57**: `git diff origin/jazzy...HEAD` on `hypothesis.{cpp,h}`, `error_model.cpp`, `common.h`, `store_import.*`, `import_bag_main.cpp`, `test_store_import.cpp`, `CMakeLists.txt` = 0 lines. #54 API and #57 importer byte-identical to jazzy. No duplicated field/function/include/find_package.
+
+### Notes
+- Two fresh-context adversarial passes (Lens A composition-logic, Lens B merge-integrity) both clean. Lens A confirmed offset never leaks into intensity, queue keeps depth+intensity+beam_angle bound through median sort/extraction, and recordBeam lands on the corrected winning hypothesis (intended). Lens B confirmed `HEAD = jazzy(#54+#57) ⊎ #15` with no drop/dup.
+- Static analysis (cpplint, cppcheck, uncrustify, copyright) 0 failures on the changed files; working tree clean, so the post-merge build/test artifacts (`build/cube_bathymetry/test_results/`) match source.
+- Publish-checkpoint reminders still stand from Round 1: file the deferred predicted-surface producer follow-on; PR body must state slope correction stays inert (offset 0) in production until it lands.

--- a/cube_bathymetry/include/cube_bathymetry/node.h
+++ b/cube_bathymetry/include/cube_bathymetry/node.h
@@ -183,6 +183,31 @@ public:
  */
     void queueFlush(const Parameters & parameters);
 
+  /* Routine:  cube_node_set_preddepth
+  * Purpose:  Set the node's notion of a 'predicted depth'
+  * Inputs:  depth  Depth to set (meter), negative-down
+  *          variance  Variance of depth to set (meter^2)
+  * Comment: 1:1 port of `cube_node_set_preddepth` (`cube_node.c:1084`). This is
+  *          simply a predicted-depth setter made available to the outside world
+  *          on the basis that the Node code should be doing this, rather than
+  *          some other part of the module. The following conventions apply in
+  *          the integration code:
+  *            pred_depth == NaN     => Do not incorporate any data into node
+  *            pred_depth == INVALID => No prediction of depth available (so the
+  *                                     node has to guess, and does NOT make
+  *                                     slope corrections).
+  *          No producer wires this in production yet; it exists so the future
+  *          external-prior load path (and the tests) can seed a predicted
+  *          surface that drives the slope correction in Node::insert.
+  */
+    void setPredictedDepth(float depth, float variance);
+
+  /// Current predicted-surface depth at this node (negative-down), or
+  /// `INVALID_DATA` when no prediction is available. Accessor for the
+  /// predicted-surface producer and tests; the running best-estimate of the
+  /// seabed is extracted separately via extractDepthAndUncertainty().
+    float predictedDepth() const {return predicted_depth_;}
+
 private:
   /// Queued points in pre-filter
     std::list < DepthAndUncertainty > queue_;

--- a/cube_bathymetry/include/cube_bathymetry/sounding.h
+++ b/cube_bathymetry/include/cube_bathymetry/sounding.h
@@ -67,6 +67,34 @@ namespace cube
   /// Per-beam acoustic intensity / backscatter (NaN when not reported).
     float intensity = std::nan("");
 
+  /// Predicted-seabed-surface depth interpolated at this sounding's touchdown
+  /// point, negative-down (same convention as `depth` and `Node`'s
+  /// `predicted_depth_`). This is the port's analog of the original CUBE
+  /// sounding's *overwritten* `range` element: in `mapsheet_cube.c:2434` the
+  /// integration code fills `snd->range` with
+  /// `cube_grid_interpolate(... de, dn ...)` — the bilinear blend of the four
+  /// surrounding nodes' `pred_depth` at the touchdown `(de,dn)` — purely so
+  /// that `cube_node_insert` (`cube_node.c:1846`) can use it for the
+  /// slope correction `offset = node->pred_depth - snd->range`.
+  ///
+  /// It is deliberately NOT named `range` to avoid resurrecting the prior
+  /// misread that equated it with the error-model slant range
+  /// `depth/cos(angle)` (`sounding.c:1268`); that is a different quantity that
+  /// is overwritten before the offset runs and is irrelevant here.
+  ///
+  /// Defaults to the no-correction sentinel `INVALID_DATA`. The original uses
+  /// `range == 0.0` as its "no interpolation result" sentinel only because
+  /// `cube_grid_interpolate` *returns* `0.0f` on a no-data corner
+  /// (`cube_grid.c:2383`); `0.0` is an artifact of that return convention, not
+  /// a deliberate semantic, and is safe there only because a real seabed
+  /// `pred_depth` is never exactly `0.0` m. In this port a legitimately
+  /// interpolated touchdown depth at the shoreline could be `0.0`, so we use
+  /// `INVALID_DATA` to carry the same intent ("no interpolation result =>
+  /// skip") without the value collision. No producer sets this yet (the
+  /// external-prior + touchdown-interpolation subsystem is a deferred
+  /// follow-on), so it stays at the sentinel and the offset is 0.
+    float predicted_depth_at_touchdown = INVALID_DATA;
+
   // Position relative to the sonar head, in meters.
   // For a typical down looking sonar, x is along the heading, y is to starboard, and z is down.
     geometry_msgs::msg::Point sonar_relative_position;

--- a/cube_bathymetry/src/node.cpp
+++ b/cube_bathymetry/src/node.cpp
@@ -115,13 +115,41 @@ bool Node::insert(double distance, const Sounding & sounding, const Parameters &
       parameters.distance_exponent));
 
 
-  // if (sounding.range != 0.0 && predicted_depth_  != parameters.no_data_value)
-  // {
-  //   offset = predicted_depth_ - sounding.range;
-  //   /* Refered variance is boresight variance multiplied by dilution factor,
-  //    * a function of distance and a user scale parameter.
-  //    */
-  // }
+  /* Slope correction. Projects a sounding that touched down off this node onto
+   * the node along the predicted seabed surface (not along the acoustic beam):
+   *
+   *   offset = predicted_depth_(node) - predicted_depth_at_touchdown
+   *   queued = sounding.depth + offset
+   *
+   * Both terms are negative-down predicted-surface depths in the same
+   * convention, so the offset is purely the predicted slope between the node
+   * and the sounding's touchdown point. This is the original CUBE
+   * `offset = node->pred_depth - snd->range` (`cube_node.c:1846`) once you
+   * account for `snd->range` being OVERWRITTEN at `mapsheet_cube.c:2434` with
+   * `cube_grid_interpolate(... de, dn ...)` (the bilinear blend of the four
+   * surrounding nodes' pred_depth at the touchdown). There is no 1/cos^2
+   * obliquity factor: the error-model slant range `depth/cos(angle)`
+   * (`sounding.c:1268`) is a different quantity that is overwritten before the
+   * offset runs and is irrelevant here.
+   *
+   * Disabled at port time because the port had no `range`/predicted-surface
+   * field to drive it. Re-enabled here using the new
+   * `Sounding::predicted_depth_at_touchdown` field; the guard reproduces the
+   * original's `range != 0.0 && pred_depth != no_data_value` exactly, with both
+   * sentinels expressed as `INVALID_DATA` (the live blunder check above uses
+   * `INVALID_DATA`; the original commented-out guard referenced
+   * `parameters.no_data_value`, which is `quiet_NaN()` here — doubly wrong, so
+   * it is deliberately corrected). With no producer wired yet (the
+   * external-prior load + touchdown-interpolation subsystem is a deferred
+   * follow-on), `predicted_depth_at_touchdown` stays at its `INVALID_DATA`
+   * sentinel => offset 0 => the defined, safe, correct-but-uncorrected behaviour
+   * the grids have today.
+   */
+  if (sounding.predicted_depth_at_touchdown != INVALID_DATA &&
+    predicted_depth_ != INVALID_DATA)
+  {
+    offset = predicted_depth_ - sounding.predicted_depth_at_touchdown;
+  }
 
   /* Adding data removes any nomination in effect */
   nominated_hypothesis_.reset();
@@ -229,6 +257,16 @@ void Node::truncate(const Parameters & parameters)
       ++i;
     }
   }
+}
+
+
+void Node::setPredictedDepth(float depth, float variance)
+{
+  // 1:1 port of cube_node_set_preddepth (cube_node.c:1084): a trivial setter.
+  // pred_depth == NaN     => do not incorporate any data into the node
+  // pred_depth == INVALID => no prediction available (no slope correction)
+  predicted_depth_ = depth;
+  predicted_depth_variance_ = variance;
 }
 
 

--- a/cube_bathymetry/src/node.cpp
+++ b/cube_bathymetry/src/node.cpp
@@ -21,6 +21,7 @@
 
 
 #include "cube_bathymetry/node.h"
+#include <cassert>
 #include <cmath>
 
 namespace cube
@@ -265,6 +266,16 @@ void Node::setPredictedDepth(float depth, float variance)
   // 1:1 port of cube_node_set_preddepth (cube_node.c:1084): a trivial setter.
   // pred_depth == NaN     => do not incorporate any data into the node
   // pred_depth == INVALID => no prediction available (no slope correction)
+  //
+  // Precondition: a *real* predicted depth must carry a finite, positive,
+  // non-sentinel variance. insert()'s blunder limit uses sqrt(predicted_depth_-
+  // variance_), so pairing a valid depth with an INVALID_DATA (= float max)
+  // variance would make sqrt(.) ~1e19 and silently neutralize blunder rejection.
+  // No producer wires this yet; the assert guards the future external-prior path.
+  assert(
+    (depth == INVALID_DATA || std::isnan(depth) ||
+    (std::isfinite(variance) && variance > 0.0F && variance != INVALID_DATA)) &&
+    "setPredictedDepth: a real predicted depth requires a finite positive variance");
   predicted_depth_ = depth;
   predicted_depth_variance_ = variance;
 }

--- a/cube_bathymetry/src/node.cpp
+++ b/cube_bathymetry/src/node.cpp
@@ -265,9 +265,10 @@ NodeRecord Node::extractNodeRecord(const Parameters & parameters)
   //
   // TODO(#54-B / cube_bathymetry#15): apply the GeoCoder incidence/Lambert
   // correction per beam HERE, using the winning hypothesis's settled depth and
-  // the local seabed slope (ADR-0007 D3). Slope is gated on cube_bathymetry#15
-  // (disabled today in Node::insert). Until #15 lands this is the identity
-  // (flat-geometry) correction: the corrected value equals the raw value and
+  // the local seabed slope (ADR-0007 D3). The slope correction (cube_bathymetry#15)
+  // has landed in Node::insert but is inert (offset 0) until its predicted-surface
+  // producer (cube_bathymetry#59) is wired. Until that producer lands this is the
+  // identity (flat-geometry) correction: the corrected value equals the raw value and
   // intensity is emitted UNCORRECTED. The per-beam {raw_intensity, grazing_angle}
   // set is retained on the hypothesis (Hypothesis::intensity_samples) so the
   // node value is fully re-derivable when #15 provides slope -- no information

--- a/cube_bathymetry/test/test_node.cpp
+++ b/cube_bathymetry/test/test_node.cpp
@@ -185,4 +185,125 @@ TEST_F(NodeTest, MultipleConsistentUpdatesConverge)
   EXPECT_NEAR(result.depth, 15.0, 0.1);
 }
 
+// --- Slope correction (issue #15) ------------------------------------------
+//
+// The re-enabled offset in Node::insert is the predicted-SURFACE slope delta
+//   offset = predicted_depth_(node) - sounding.predicted_depth_at_touchdown
+// (both negative-down predicted-surface depths), queued as
+//   sounding.depth + offset.
+// The discriminator against the two prior wrong formulas (.z vertical component
+// and depth/cos(angle)) is the TOUCHDOWN-POSITION delta along a known synthetic
+// prior surface; the corrected offset is angle-independent. Each test below
+// reconstructs the expected value INDEPENDENTLY from pred_node - pred_touchdown,
+// it does not echo the implementation. Soundings are inserted repeatedly and
+// flushed so the median/CUBE estimate converges to the queued corrected depth,
+// which is what extractDepthAndUncertainty() returns.
+
+// Helper: a sounding sited off-node whose touchdown predicted-surface depth is
+// supplied directly (the per-sounding analog of the original's overwritten
+// snd->range), with the variances the insert path needs.
+static Sounding makeSlopeSounding(float depth, float predicted_depth_at_touchdown)
+{
+  Sounding s(depth);
+  s.predicted_depth_at_touchdown = predicted_depth_at_touchdown;
+  s.vertical_error = 0.01f;
+  s.horizontal_error = 0.0f;
+  return s;
+}
+
+TEST_F(NodeTest, SlopeCorrectionSurfaceSlopeDelta)
+{
+  // Known synthetic prior surface: node sits at -10.0 m, the sounding touched
+  // down at a point where the prior surface is -10.6 m (0.6 m deeper, i.e. a
+  // genuine slope between node and touchdown). The raw sounding depth is -10.5.
+  const float pred_node = -10.0f;
+  const float pred_touchdown = -10.6f;
+  const float depth = -10.5f;
+
+  // Independent reconstruction of the expected corrected depth:
+  //   queued = depth + (pred_node - pred_touchdown)
+  // Deliberately NOT pred_node (the v1 .z trap) and NOT pred - depth/cos (v2).
+  const float expected = depth + (pred_node - pred_touchdown);  // = -9.9
+
+  Node n;
+  n.setPredictedDepth(pred_node, 0.01f);
+
+  // Insert the same off-node sounding many times so the estimate converges to
+  // the queued corrected value, then flush the pre-filter queue.
+  for (int i = 0; i < 20; ++i) {
+    EXPECT_TRUE(n.insert(0.0, makeSlopeSounding(depth, pred_touchdown), params));
+  }
+  n.queueFlush(params);
+
+  auto result = n.extractDepthAndUncertainty(params);
+  ASSERT_FALSE(std::isnan(result.depth));
+  EXPECT_NEAR(result.depth, expected, 0.05);
+  // Sanity: it must NOT collapse to pred_node (v1) or to the raw depth (no corr).
+  EXPECT_GT(std::abs(result.depth - pred_node), 0.05);
+  EXPECT_GT(std::abs(result.depth - depth), 0.05);
+}
+
+TEST_F(NodeTest, SlopeCorrectionZeroOnFlatSurface)
+{
+  // Touchdown predicted depth equals the node predicted depth => offset 0 =>
+  // queued depth is the raw sounding depth, uncorrected.
+  const float pred_node = -10.0f;
+  const float depth = -10.5f;
+
+  Node n;
+  n.setPredictedDepth(pred_node, 0.01f);
+  for (int i = 0; i < 20; ++i) {
+    EXPECT_TRUE(n.insert(0.0, makeSlopeSounding(depth, pred_node), params));
+  }
+  n.queueFlush(params);
+
+  auto result = n.extractDepthAndUncertainty(params);
+  ASSERT_FALSE(std::isnan(result.depth));
+  EXPECT_NEAR(result.depth, depth, 0.05);
+}
+
+TEST_F(NodeTest, NoSlopeCorrectionWhenTouchdownSentinel)
+{
+  // predicted_depth_ is set on the node, but the sounding carries the
+  // no-correction sentinel (INVALID_DATA) for its touchdown depth => offset 0.
+  const float pred_node = -10.0f;
+  const float depth = -10.5f;
+
+  Node n;
+  n.setPredictedDepth(pred_node, 0.01f);
+  for (int i = 0; i < 20; ++i) {
+    // Default Sounding leaves predicted_depth_at_touchdown == INVALID_DATA.
+    Sounding s(depth);
+    s.vertical_error = 0.01f;
+    s.horizontal_error = 0.0f;
+    EXPECT_TRUE(n.insert(0.0, s, params));
+  }
+  n.queueFlush(params);
+
+  auto result = n.extractDepthAndUncertainty(params);
+  ASSERT_FALSE(std::isnan(result.depth));
+  EXPECT_NEAR(result.depth, depth, 0.05);  // offset 0: queued == raw depth
+}
+
+TEST_F(NodeTest, NoSlopeCorrectionWhenPredictedDepthInvalid)
+{
+  // The node has no prediction (predicted_depth_ == INVALID_DATA by default),
+  // even though the sounding supplies a touchdown depth => offset 0. This is
+  // the unwired production path: with no prior surface loaded, behaviour is
+  // unchanged correct-but-uncorrected.
+  const float depth = -10.5f;
+  const float pred_touchdown = -10.6f;
+
+  Node n;  // predicted_depth_ defaults to INVALID_DATA, nothing sets it.
+  EXPECT_EQ(n.predictedDepth(), INVALID_DATA);
+  for (int i = 0; i < 20; ++i) {
+    EXPECT_TRUE(n.insert(0.0, makeSlopeSounding(depth, pred_touchdown), params));
+  }
+  n.queueFlush(params);
+
+  auto result = n.extractDepthAndUncertainty(params);
+  ASSERT_FALSE(std::isnan(result.depth));
+  EXPECT_NEAR(result.depth, depth, 0.05);  // offset 0: queued == raw depth
+}
+
 }  // namespace cube


### PR DESCRIPTION
Closes #15. Follow-on: #59.

Re-enables the CUBE **slope correction** in `Node::insert` that the C++ port had commented out — ported faithfully from the original Calder CUBE, with the node-level math landing here and the predicted-surface *producer* deferred to #59.

### What this does
- **Corrected offset**: `offset = predicted_depth_(node) − sounding.predicted_depth_at_touchdown` (both negative-down), queued as `sounding.depth + offset` — i.e. a **predicted-surface slope delta**, matching the original once you account for `snd->range` being *overwritten* with the touchdown predicted depth at `mapsheet_cube.c:2434`. There is **no** `1/cos²` obliquity factor and no beam-angle term.
- `Node::setPredictedDepth()` (1:1 port of `cube_node_set_preddepth`) + a `predictedDepth()` accessor, with a precondition guard (a valid predicted depth requires a finite positive variance — the blunder limit uses `sqrt(variance)`).
- **Producer deferred** (#59): nothing seeds `predicted_depth_` / `predicted_depth_at_touchdown` in production, so both stay `INVALID_DATA` ⇒ offset 0 ⇒ **unchanged correct-but-uncorrected behaviour** for `Grid` and `GeoGrid`. Not dead code — exercised end-to-end via synthetic injection in tests.

### Tests (`test_node.cpp`, +4 → 16/0/0; full suite 0 failures)
Off-boresight slope-delta (expected reconstructed **independently** from `pred_node − pred_touchdown`, so an offset-0 regression fails), flat-surface zero-offset, and the two sentinel/unwired paths.

### Why it took the long way (review caught real bugs)
This went through `/run-issue`; three plan rounds killed two plausible-but-wrong formulas before any code — v1 used the vertical `.z` component (an obliquity error), v2 used `depth/cos(angle)` plus an invented self-bootstrap. Both would have **silently corrupted bathymetry off-boresight**. The committed formula was independently re-verified against `original_cube/` by multiple fresh-context passes.

### Scope note
`#15` lands correct, tested, faithful math that is **inactive in production until #59** wires the external-prior producer. It's a prerequisite for both slope-terrain bathy accuracy and the GeoCoder backscatter incidence correction (ADR-0007).

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
