### PR TITLE
Remove dead negative-speed guard in horizontal_latency (#16)

### DIFF
--- a/cube_bathymetry/src/error_model.cpp
+++ b/cube_bathymetry/src/error_model.cpp
@@ -175,10 +175,9 @@ double ErrorModel::horizontal_latency(
   // Eqn. 3.97
     static_error_sources_.total_latency_variance * per_ping_sources.cos_pitch *
     per_ping_sources.cos_pitch;
-  auto vessel_speed = platform.vessel_speed;
-  if(!std::isnan(platform.vessel_speed)) {
-    vessel_speed = platform.vessel_speed;  // Avoid negative speed
-  }
+  // Speed enters every latency term squared (jitter/head/pitch), so the sign of
+  // vessel_speed is irrelevant and no negative-speed guard is required; this
+  // matches Calder's errmod_iho, which applies no abs/clamp here either.
   double head_error = platform.vessel_speed * platform.vessel_speed *
     vessel_.gps_latency * vessel_.gps_latency * (M_PI / 180.0) * (M_PI / 180.0) *
   // Eqn. 3.98

--- a/cube_bathymetry/test/test_error_model.cpp
+++ b/cube_bathymetry/test/test_error_model.cpp
@@ -114,6 +114,36 @@ TEST_F(ErrorModelTest, ErrorsAreNonNegative)
   }
 }
 
+// Regression for #16: vessel speed enters every horizontal-latency term squared,
+// so the horizontal error is identical for +v and -v. This documents why no
+// negative-speed guard is needed in horizontal_latency() (the removed dead code
+// claimed to "avoid negative speed" but the squaring already neutralizes sign).
+TEST_F(ErrorModelTest, HorizontalErrorIsInsensitiveToVesselSpeedSign)
+{
+  ErrorModel em(vessel, device);
+  auto det = makeDetections({0.0f}, 0.02f);  // nadir → cos_pitch term maximal
+
+  auto p_pos = makePlatform();
+  p_pos.vessel_speed = 5.0f;
+  auto p_neg = makePlatform();
+  p_neg.vessel_speed = -5.0f;
+  auto p_zero = makePlatform();
+  p_zero.vessel_speed = 0.0f;
+
+  auto s_pos = em.compute(det, p_pos);
+  auto s_neg = em.compute(det, p_neg);
+  auto s_zero = em.compute(det, p_zero);
+  ASSERT_EQ(s_pos.size(), 1u);
+  ASSERT_EQ(s_neg.size(), 1u);
+  ASSERT_EQ(s_zero.size(), 1u);
+
+  // Sign-insensitive: +v and -v give the same horizontal error.
+  EXPECT_FLOAT_EQ(s_pos[0].horizontal_error, s_neg[0].horizontal_error);
+  // And the speed path is genuinely exercised: nonzero speed adds latency error
+  // on top of the zero-speed baseline (otherwise the equality above is vacuous).
+  EXPECT_GT(s_pos[0].horizontal_error, s_zero[0].horizontal_error);
+}
+
 TEST_F(ErrorModelTest, VerticalErrorIncreasesWithBeamAngle)
 {
   ErrorModel em(vessel, device);


### PR DESCRIPTION
## Summary

Closes #16. Removes the dead negative-speed guard in `ErrorModel::horizontal_latency()`.

The local `vessel_speed` was assigned `platform.vessel_speed`, re-assigned the **same**
value inside an `isnan()` check, then never used — every latency term reads
`platform.vessel_speed` directly. The `// Avoid negative speed` comment described a hazard
that does not exist: speed enters the jitter / head / pitch latency terms **squared**, so
its sign is irrelevant. Calder's `errmod_iho` applies no `abs`/clamp here either, so
removing the dead code keeps the port faithful (no behavior change).

## Changes
- `error_model.cpp` — remove the dead local + no-op `if`; replace with a comment explaining
  why no negative-speed guard is needed.
- `test_error_model.cpp` — new regression test `HorizontalErrorIsInsensitiveToVesselSpeedSign`:
  asserts `horizontal_error(+v) == horizontal_error(-v)` **and** that nonzero speed adds
  latency error over the zero-speed baseline (so the equality is not vacuous).

## Verification
333 tests, 0 failures, 46 skipped (was 332 + this regression). cpplint + uncrustify clean.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8`
