### PR TITLE
Make offline M3 bathy import produce tiles and run in minutes (#63)

### DIFF
--- a/cube_bathymetry/CMakeLists.txt
+++ b/cube_bathymetry/CMakeLists.txt
@@ -1,6 +1,16 @@
 cmake_minimum_required(VERSION 3.14.4)
 project(cube_bathymetry)
 
+# This package carries the compute-heavy CUBE estimator + the offline importers
+# (import_bag / bag_to_geotiff). colcon supplies no CMAKE_BUILD_TYPE by default,
+# which builds at -O0 and makes import_bag ~10-50x slower (an hours-long offline
+# import instead of minutes). Default to an optimized build when the workspace
+# didn't pick one (cube_bathymetry#63).
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Default optimized build" FORCE)
+  message(STATUS "cube_bathymetry: defaulting CMAKE_BUILD_TYPE to RelWithDebInfo")
+endif()
+
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()
@@ -19,7 +29,6 @@ find_package(marine_acoustic_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)  # odometry for speed-over-ground
 find_package(marine_autonomy REQUIRED)
 find_package(marine_bathymetry_store REQUIRED)  # store epoch import (#57)
-find_package(geodesy REQUIRED)  # WGS84 Vincenty inverse (geo_grid distance)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(rosbag2_cpp REQUIRED)
@@ -64,8 +73,6 @@ target_link_libraries(cube_bathymetry
   tf2::tf2
   tf2_geometry_msgs::tf2_geometry_msgs
 )
-# geodesy (geographic_info) exports via ament, not a namespaced target.
-ament_target_dependencies(cube_bathymetry geodesy)
 
 install(TARGETS cube_bathymetry EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
@@ -180,6 +187,7 @@ target_link_libraries(import_bag
   cube_bathymetry_store_import   # brings in cube_bathymetry + marine_bathymetry_store
   ${geometry_msgs_TARGETS}
   ${marine_acoustic_msgs_TARGETS}
+  ${nav_msgs_TARGETS}
   rclcpp::rclcpp
   rosbag2_cpp::rosbag2_cpp
   rosbag2_transport::rosbag2_transport

--- a/cube_bathymetry/package.xml
+++ b/cube_bathymetry/package.xml
@@ -26,7 +26,6 @@
        the need for an explicit find_package(nlohmann_json) (the store now exports it),
        but not the build-time install dependency. -->
   <depend>nlohmann-json-dev</depend>
-  <depend>geodesy</depend>
   <depend>rclcpp</depend>
   <depend>rosbag2_cpp</depend>  <!-- bag readers in import_bag / bag_to_geotiff -->
   <depend>rosbag2_transport</depend>

--- a/cube_bathymetry/src/error_model.cpp
+++ b/cube_bathymetry/src/error_model.cpp
@@ -171,19 +171,28 @@ double ErrorModel::horizontal_latency(
   double sog_error = vessel_.gps_latency * vessel_.gps_latency * vessel_.sog_sdev *
     vessel_.sog_sdev * per_ping_sources.cos_pitch * per_ping_sources.cos_pitch;
 
-  double jitter_error = platform.vessel_speed * platform.vessel_speed *
+  // Floor a non-finite speed (offline replay supplies NaN; a corrupt odom twist
+  // could yield +/-inf) to 0 so the speed-dependent terms below stay finite. A
+  // non-finite value here propagates through horizontal TPU and, via the
+  // Node::insert capture-distance term (sqrt(horizontal_error)), poisons the
+  // depth variance and zeroes the whole epoch (cube_bathymetry#63); Node::insert
+  // mirrors this isfinite defense on the same quantity downstream. A finite
+  // speed's sign is left untouched: it enters every latency term squared
+  // (jitter/head/pitch), so the sign is irrelevant and Calder's errmod_iho
+  // applies no abs/clamp here either (#16).
+  const double vessel_speed =
+    std::isfinite(platform.vessel_speed) ? platform.vessel_speed : 0.0;
+
+  double jitter_error = vessel_speed * vessel_speed *
   // Eqn. 3.97
     static_error_sources_.total_latency_variance * per_ping_sources.cos_pitch *
     per_ping_sources.cos_pitch;
-  // Speed enters every latency term squared (jitter/head/pitch), so the sign of
-  // vessel_speed is irrelevant and no negative-speed guard is required; this
-  // matches Calder's errmod_iho, which applies no abs/clamp here either.
-  double head_error = platform.vessel_speed * platform.vessel_speed *
+  double head_error = vessel_speed * vessel_speed *
     vessel_.gps_latency * vessel_.gps_latency * (M_PI / 180.0) * (M_PI / 180.0) *
   // Eqn. 3.98
     vessel_.gyro_sdev * vessel_.gyro_sdev * per_ping_sources.cos_pitch * per_ping_sources.cos_pitch;
 
-  double pitch_error = platform.vessel_speed * platform.vessel_speed *
+  double pitch_error = vessel_speed * vessel_speed *
     vessel_.gps_latency * vessel_.gps_latency * static_error_sources_.total_pitch_variance *
     per_ping_sources.sin_pitch * per_ping_sources.sin_pitch;
 

--- a/cube_bathymetry/src/geo_grid.cpp
+++ b/cube_bathymetry/src/geo_grid.cpp
@@ -22,8 +22,6 @@
 
 #include "cube_bathymetry/geo_grid.h"
 #include <cmath>
-#include "geodesy/geodesics.h"
-#include "geodesy/wgs84_ellipsoid.h"
 #include "marine_autonomy/gz4d_geo.h"
 
 namespace cube
@@ -79,15 +77,24 @@ bool GeoGrid::insert(const GeoSounding & geo_sounding)
     gggs::geoPoint(bounds.minimum().latitude, bounds.minimum().longitude),
     gggs::geoPoint(bounds.maximum().latitude, bounds.maximum().longitude));
 
-  // CellIndex::position() returns a GeoPoint; distance to the sounding now
-  // comes from geodesy's WGS84 Vincenty inverse (replacing the gz4d
-  // Position::distanceFrom() the GeoPoint type doesn't provide).
-  const auto sounding_point =
-    gggs::geoPoint(geo_sounding.latitude, geo_sounding.longitude);
+  // Local-planar (equirectangular) cell->sounding distance in metres. This runs
+  // per cell x per sounding x per ping; the #144 gz4d->GeoPoint refactor had put
+  // a WGS84 Vincenty inverse here -- a full iterative ellipsoidal solver -- for
+  // what is a sub-metre cell-to-sounding distance. At these radii (a few metres)
+  // the equirectangular distance matches the geodesic to well under a millimetre,
+  // so the iterative solver was pure overhead in both the offline import and the
+  // live node (cube_bathymetry#63). Latitude scale is fixed at the sounding (the
+  // cells span only metres around it).
+  static constexpr double kDeg2Rad = M_PI / 180.0;
+  static constexpr double kEarthRadiusM = 6378137.0;  // WGS84 semi-major axis
+  const double cos_lat = std::cos(geo_sounding.latitude * kDeg2Rad);
 
   bool inserted = false;
   while(i.valid()) {
-    auto distance = geodesy::wgs84::inverse(i->position(), sounding_point).distance;
+    const auto cell = i->position();
+    const double dlat = (cell.latitude - geo_sounding.latitude) * kDeg2Rad;
+    const double dlon = (cell.longitude - geo_sounding.longitude) * kDeg2Rad * cos_lat;
+    const double distance = std::hypot(dlat, dlon) * kEarthRadiusM;
     if(distance < radius) {
       if(!nodes_[*i]) {
         nodes_[*i] = std::make_shared<Node>();

--- a/cube_bathymetry/src/import_bag_main.cpp
+++ b/cube_bathymetry/src/import_bag_main.cpp
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <deque>
 #include <iomanip>
 #include <iostream>
 #include <limits>
@@ -47,6 +48,7 @@
 #include "geometry_msgs/msg/point_stamped.hpp"
 #include "marine_acoustic_msgs/msg/sonar_detections.hpp"
 #include "marine_autonomy/gz4d_geo.h"
+#include "nav_msgs/msg/odometry.hpp"
 #include "marine_bathymetry_store/bathymetry_store.hpp"
 #include "marine_bathymetry_store/epoch.hpp"
 #include "marine_bathymetry_store/registry.hpp"
@@ -55,6 +57,7 @@
 #include "rosbag2_transport/reader_writer_factory.hpp"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"
+#include "tf2/time.h"
 #include "tf2_ros/buffer.h"
 
 void usage()
@@ -67,6 +70,9 @@ void usage()
     "2026-06-15)\n";
   std::cout << "  -d <detections_topic>: marine_acoustic_msgs/SonarDetections "
     "topic to replay through CUBE (required)\n";
+  std::cout << "  --odom-topic <topic>: nav_msgs/Odometry topic for per-ping "
+    "vessel speed-over-ground (optional; without it the speed-dependent "
+    "horizontal-TPU terms are floored to 0)\n";
   std::cout << "  -r <meters>: Grid resolution (nominal; snapped to GGGS). "
     "Default 1.0\n";
   std::cout << "  --iho-order <order>: CUBE IHO order (default order1a)\n";
@@ -82,10 +88,38 @@ void usage()
   exit(-1);
 }
 
-bool bag_filter(const std::string & type)
+// Speed-over-ground (m/s) nearest @p ns in the odometry timeline. Returns NaN
+// when the timeline is empty OR the nearest sample is more than kSpeedMaxAgeNs
+// away (an odom dropout) -- the error model then floors the speed-dependent
+// horizontal-TPU terms to 0, the same as having no odometry at all, rather than
+// applying an arbitrarily stale speed (cube_bathymetry#63 review).
+float speedAt(const std::map<int64_t, double> & by_ns, int64_t ns)
 {
-  return type == "tf2_msgs/msg/TFMessage" ||
-         type == "marine_acoustic_msgs/msg/SonarDetections";
+  // Max staleness for a usable speed sample. Generous vs typical odom rates
+  // (tens of Hz) so normal jitter never trips it; trips only on a real dropout.
+  constexpr int64_t kSpeedMaxAgeNs = 5LL * 1000000000LL;
+  if (by_ns.empty()) {
+    return std::nanf("");
+  }
+  auto it = by_ns.lower_bound(ns);
+  int64_t nearest_ns;
+  double nearest_speed;
+  if (it == by_ns.end()) {
+    nearest_ns = std::prev(it)->first;
+    nearest_speed = std::prev(it)->second;
+  } else if (it == by_ns.begin()) {
+    nearest_ns = it->first;
+    nearest_speed = it->second;
+  } else {
+    auto prev = std::prev(it);
+    const bool prev_closer = (ns - prev->first <= it->first - ns);
+    nearest_ns = prev_closer ? prev->first : it->first;
+    nearest_speed = prev_closer ? prev->second : it->second;
+  }
+  if (std::llabs(ns - nearest_ns) > kSpeedMaxAgeNs) {
+    return std::nanf("");
+  }
+  return static_cast<float>(nearest_speed);
 }
 
 bool ends_with(const std::string & str, const std::string & suffix)
@@ -229,6 +263,7 @@ int main(int argc, char * argv[])
   std::string store_dir;
   std::string epoch_label;
   std::string detections_topic;  // required
+  std::string odom_topic;  // optional: nav_msgs/Odometry for per-ping vessel speed
   double resolution = 1.0;
   std::string iho_order = "order1a";
   int ping_count_limit = 0;
@@ -254,6 +289,9 @@ int main(int argc, char * argv[])
     } else if (*arg == "-d") {
       arg++;
       detections_topic = *arg;
+    } else if (*arg == "--odom-topic") {
+      arg++;
+      odom_topic = *arg;
     } else if (*arg == "-r") {
       arg++;
       resolution = std::stod(*arg);
@@ -329,6 +367,7 @@ int main(int argc, char * argv[])
   size_t proj_filtered_range = 0;
   size_t proj_missing_attitude = 0;
   size_t proj_missing_heave = 0;
+  size_t proj_dropped_georef = 0;  // pings with no earth transform at their stamp
 
   BagReaders bag_readers(bagfile_names);
 
@@ -354,8 +393,18 @@ int main(int argc, char * argv[])
     std::chrono::duration_cast<std::chrono::nanoseconds>(
     begin_time.time_since_epoch()).count();
 
+  // Bounded TF cache: the offline projection only needs the transforms
+  // bracketing each ping's stamp, so a small rolling window keeps tf2's
+  // std::list-backed TimeCache short. Whole-bag buffering made every
+  // lookupTransform an O(n) linear list walk (~7 pings/s; cube_bathymetry#63).
+  // The guard is how far the TF frontier must advance past a ping before we
+  // project it, so both bracketing transforms are present (no frontier drops).
+  constexpr double kCacheWindowSec = 60.0;
+  constexpr double kGuardSec = 3.0;
+  const int64_t kGuardNs = static_cast<int64_t>(kGuardSec * 1e9);
+
   auto clock = std::make_shared<rclcpp::Clock>();
-  tf2_ros::Buffer tfBuffer(clock, total_duration);
+  tf2_ros::Buffer tfBuffer(clock, tf2::durationFromSec(kCacheWindowSec));
 
   cube::GeoMapSheet geo_map_sheet(resolution, iho_order);
   std::cout << "requested resolution: " << resolution << " nominal used: "
@@ -364,122 +413,234 @@ int main(int argc, char * argv[])
   std::cout << "reading messages..." << std::endl;
 
   int ping_count = 0;
-  uint64_t msg_count = 0;
   auto last_report_time = std::chrono::system_clock::now();
-  std::chrono::seconds report_interval(1);
+  const std::chrono::seconds report_interval(1);
 
-  for (auto message = bag_readers.next(); message; message = bag_readers.next()) {
-    if (!bag_filter(message->data_type)) {
-      continue;
-    }
-    ++msg_count;
+  // SINGLE INTERLEAVED PASS over the chronological message stream. TF is fed
+  // into the bounded-window buffer as it arrives; each detection waits in a
+  // short FIFO until the TF frontier has advanced a guard interval past its
+  // stamp, so its bracketing transforms (both sides) are present before we
+  // project -- the correctness the old whole-bag 2-pass bought, but without the
+  // O(n) lookup cost of a 100k-entry-per-frame TimeCache (cube_bathymetry#63).
+  auto phase_tp = std::chrono::steady_clock::now();
+  auto phase_secs = [&phase_tp]() {
+      auto now = std::chrono::steady_clock::now();
+      double s = std::chrono::duration<double>(now - phase_tp).count();
+      phase_tp = now;
+      return s;
+    };
 
-    if (message->data_type == "tf2_msgs/msg/TFMessage") {
-      if (ends_with(message->message->topic_name, "/tf_static")) {
-        rclcpp::SerializedMessage serialized_message(*message->message->serialized_data);
-        tf2_msgs::msg::TFMessage tf_message;
-        rclcpp::Serialization<tf2_msgs::msg::TFMessage>().deserialize_message(
-          &serialized_message, &tf_message);
-        for (const auto & t : tf_message.transforms) {
-          tfBuffer.setTransform(t, "", true);
-        }
-      }
-      if (ends_with(message->message->topic_name, "/tf")) {
-        try {
-          rclcpp::SerializedMessage serialized_message(*message->message->serialized_data);
-          tf2_msgs::msg::TFMessage tf_message;
-          rclcpp::Serialization<tf2_msgs::msg::TFMessage>().deserialize_message(
-            &serialized_message, &tf_message);
-          for (const auto & t : tf_message.transforms) {
-            tfBuffer.setTransform(t, "", false);
-          }
-          auto now = std::chrono::system_clock::now();
-          if (now >= last_report_time + report_interval && !tf_message.transforms.empty() &&
-            total_duration.count() > 0)
-          {
-            double progress =
-              (tf2_ros::fromMsg(tf_message.transforms.front().header.stamp) - begin_time)
-              .count() / static_cast<double>(total_duration.count());
-            std::cout << "\r" << static_cast<int>(100 * progress) << "%\t" << msg_count
-                      << " messages, " << ping_count << " pings            ";
-            std::cout.flush();
-            last_report_time = now;
-          }
-        } catch (const std::exception & e) {
-          std::cerr << e.what() << '\n';
-        }
-      }
-    }
+  const int64_t begin_ns = cell_timestamp_ns;
+  const int64_t total_ns =
+    std::chrono::duration_cast<std::chrono::nanoseconds>(total_duration).count();
 
-    if (message->data_type == "marine_acoustic_msgs/msg/SonarDetections" &&
-      message->message->topic_name == detections_topic)
-    {
+  std::map<int64_t, double> speed_by_ns;
+  size_t tf_count = 0;
+  int64_t tf_frontier_ns = std::numeric_limits<int64_t>::min();
+
+  // Detections awaiting their bracketing TF (ping stamp ns -> message).
+  std::deque<std::pair<int64_t, marine_acoustic_msgs::msg::SonarDetections>> pending;
+
+  bool limit_reached = false;
+
+  // Project + georeference one ping into the GeoMapSheet.
+  auto process_detection =
+    [&](const marine_acoustic_msgs::msg::SonarDetections & detections, int64_t ping_ns) {
+      // Real speed-over-ground from odom (Fix B) if available, else NaN -- the
+      // error model floors the speed-dependent horizontal-TPU terms to 0 (Fix A).
+      const float vessel_speed = speedAt(speed_by_ns, ping_ns);
+
+      auto projection = projector.project(detections, tfBuffer, vessel_speed);
+      ++proj_pings;
+      proj_soundings += projection.soundings.size();
+      proj_filtered_range += projection.diagnostics.filtered_range;
+      proj_missing_attitude += projection.diagnostics.missing_attitude;
+      proj_missing_heave += projection.diagnostics.missing_heave;
+
       try {
-        rclcpp::SerializedMessage serialized_message(*message->message->serialized_data);
-        marine_acoustic_msgs::msg::SonarDetections detections;
-        rclcpp::Serialization<marine_acoustic_msgs::msg::SonarDetections>()
-        .deserialize_message(&serialized_message, &detections);
+        auto transform = tfBuffer.lookupTransform(
+          "earth", detections.header.frame_id, detections.header.stamp);
 
-        auto projection = projector.project(detections, tfBuffer, std::nanf(""));
-        ++proj_pings;
-        proj_soundings += projection.soundings.size();
-        proj_filtered_range += projection.diagnostics.filtered_range;
-        proj_missing_attitude += projection.diagnostics.missing_attitude;
-        proj_missing_heave += projection.diagnostics.missing_heave;
+        // Per-ping geodetic reference: convert the sensor origin ECEF ->
+        // lat/long ONCE (the single iterative ECEF->geodetic solve per ping),
+        // then map each sounding's ECEF position through a local-ENU tangent
+        // plane (a cheap 4x4 matvec) + a first-order radii-of-curvature
+        // linearization. This collapses the per-sounding iterative solves into
+        // one per ping. At swath scale (tens of metres about the reference) the
+        // linearization error is well under a millimetre -- far below the GGGS
+        // cell size and the soundings' own TPU.
+        const auto & origin = transform.transform.translation;
+        gz4d::GeoPointLatLongDegrees ref_ll(
+          gz4d::GeoPointECEF(origin.x, origin.y, origin.z));
+        gz4d::LocalENU enu(ref_ll);
 
-        // Georeference each sonar-frame sounding to lat/lon via the bag's TF
-        // buffer at the ping stamp, exactly as bag_to_geotiff -d does.
-        try {
-          auto transform = tfBuffer.lookupTransform(
-            "earth", detections.header.frame_id, detections.header.stamp);
+        const double ref_lat_deg = ref_ll.latitude();
+        const double ref_lon_deg = ref_ll.longitude();
+        const double ref_height = ref_ll.altitude();
+        constexpr double kDeg2Rad = M_PI / 180.0;
+        constexpr double kRad2Deg = 180.0 / M_PI;
+        constexpr double kA = 6378137.0;             // WGS84 semi-major axis
+        constexpr double kF = 1.0 / 298.257223563;   // WGS84 flattening
+        constexpr double kE2 = kF * (2.0 - kF);       // first eccentricity^2
+        const double lat0_rad = ref_lat_deg * kDeg2Rad;
+        const double sin_lat0 = std::sin(lat0_rad);
+        const double cos_lat0 = std::cos(lat0_rad);
+        const double w = std::sqrt(1.0 - kE2 * sin_lat0 * sin_lat0);
+        const double prime_vertical = kA / w;                     // N(lat0)
+        const double meridional = kA * (1.0 - kE2) / (w * w * w);  // M(lat0)
 
-          std::vector<cube::GeoSounding> soundings;
-          soundings.reserve(projection.soundings.size());
-          for (const auto & s : projection.soundings) {
-            geometry_msgs::msg::PointStamped sounding_re_sensor;
-            sounding_re_sensor.point.x = s.sonar_relative_position.x;
-            sounding_re_sensor.point.y = s.sonar_relative_position.y;
-            sounding_re_sensor.point.z = s.sonar_relative_position.z;
-            sounding_re_sensor.header = detections.header;
+        std::vector<cube::GeoSounding> soundings;
+        soundings.reserve(projection.soundings.size());
+        for (const auto & s : projection.soundings) {
+          geometry_msgs::msg::PointStamped sounding_re_sensor;
+          sounding_re_sensor.point.x = s.sonar_relative_position.x;
+          sounding_re_sensor.point.y = s.sonar_relative_position.y;
+          sounding_re_sensor.point.z = s.sonar_relative_position.z;
+          sounding_re_sensor.header = detections.header;
 
-            geometry_msgs::msg::PointStamped sounding_ecef;
-            tf2::doTransform(sounding_re_sensor, sounding_ecef, transform);
+          geometry_msgs::msg::PointStamped sounding_ecef;
+          tf2::doTransform(sounding_re_sensor, sounding_ecef, transform);
 
-            gz4d::GeoPointECEF ecef(
-              sounding_ecef.point.x, sounding_ecef.point.y, sounding_ecef.point.z);
-            gz4d::GeoPointLatLongDegrees ll(ecef);
-            cube::GeoSounding gs(ll);
-            gs.sounding.vertical_error = s.vertical_error;
-            gs.sounding.horizontal_error = s.horizontal_error;
-            soundings.push_back(gs);
-          }
-          geo_map_sheet.addSoundings(soundings);
-          ping_count++;
-        } catch (const tf2::TransformException & e) {
-          // No earth transform at this stamp yet -- drop the ping (the bag may
-          // start before the first map->earth fix); matches bag_to_geotiff.
+          // ECEF -> local ENU (East, North, Up), then linearize ENU -> geodetic
+          // delta about the per-ping reference latitude.
+          const gz4d::Point<double> local = enu.toLocal(gz4d::GeoPointECEF(
+            sounding_ecef.point.x, sounding_ecef.point.y, sounding_ecef.point.z));
+          const double lat_deg = ref_lat_deg + (local[1] / meridional) * kRad2Deg;
+          const double lon_deg =
+            ref_lon_deg + (local[0] / (prime_vertical * cos_lat0)) * kRad2Deg;
+          const double height = ref_height + local[2];
+
+          cube::GeoSounding gs(gz4d::GeoPointLatLongDegrees(lat_deg, lon_deg, height));
+          gs.sounding.vertical_error = s.vertical_error;
+          gs.sounding.horizontal_error = s.horizontal_error;
+          soundings.push_back(gs);
+        }
+        geo_map_sheet.addSoundings(soundings);
+        ping_count++;
+      } catch (const tf2::TransformException & e) {
+        // A ping with no earth transform in the (bounded) buffer at its stamp --
+        // e.g. before the first earth fix, or a TF gap wider than the cache
+        // window. Counted (not just logged) so an empty or sparse epoch is
+        // diagnosable rather than silently dropped.
+        ++proj_dropped_georef;
+        if (proj_dropped_georef <= 5) {
           std::cerr << "Transform Exception: " << e.what() << std::endl;
         }
+      }
+    };
+
+  // Drain detections whose bracketing TF is now present (frontier advanced a
+  // guard interval past the ping stamp). With flush=true, project whatever
+  // remains at end-of-stream against the available coverage.
+  auto drain_pending = [&](bool flush) {
+      while (!pending.empty() && !limit_reached) {
+        const int64_t ping_ns = pending.front().first;
+        if (!flush && (tf_frontier_ns == std::numeric_limits<int64_t>::min() ||
+          ping_ns > tf_frontier_ns - kGuardNs))
+        {
+          break;
+        }
+        process_detection(pending.front().second, ping_ns);
+        pending.pop_front();
+        if (ping_count_limit > 0 && ping_count >= ping_count_limit) {
+          limit_reached = true;
+        }
+      }
+    };
+
+  std::cout << "projecting detections (single interleaved pass)..." << std::endl;
+  for (auto message = bag_readers.next(); message && !limit_reached;
+    message = bag_readers.next())
+  {
+    const bool is_tf = message->data_type == "tf2_msgs/msg/TFMessage";
+    const bool is_odom = !odom_topic.empty() &&
+      message->data_type == "nav_msgs/msg/Odometry" &&
+      message->message->topic_name == odom_topic;
+    const bool is_detection = message->data_type == "marine_acoustic_msgs/msg/SonarDetections" &&
+      message->message->topic_name == detections_topic;
+
+    if (is_tf) {
+      const bool is_static = ends_with(message->message->topic_name, "/tf_static");
+      if (!is_static && !ends_with(message->message->topic_name, "/tf")) {
+        continue;
+      }
+      try {
+        rclcpp::SerializedMessage sm(*message->message->serialized_data);
+        tf2_msgs::msg::TFMessage tf_message;
+        rclcpp::Serialization<tf2_msgs::msg::TFMessage>().deserialize_message(&sm, &tf_message);
+        for (const auto & t : tf_message.transforms) {
+          tfBuffer.setTransform(t, "", is_static);
+          ++tf_count;
+          if (!is_static) {
+            const int64_t ns = static_cast<int64_t>(t.header.stamp.sec) * 1000000000LL +
+              t.header.stamp.nanosec;
+            tf_frontier_ns = std::max(tf_frontier_ns, ns);
+          }
+        }
+      } catch (const std::exception & e) {
+        std::cerr << e.what() << '\n';
+      }
+      drain_pending(false);
+    } else if (is_odom) {
+      try {
+        rclcpp::SerializedMessage sm(*message->message->serialized_data);
+        nav_msgs::msg::Odometry odom;
+        rclcpp::Serialization<nav_msgs::msg::Odometry>().deserialize_message(&sm, &odom);
+        const int64_t ns = static_cast<int64_t>(odom.header.stamp.sec) * 1000000000LL +
+          odom.header.stamp.nanosec;
+        speed_by_ns[ns] = std::hypot(odom.twist.twist.linear.x, odom.twist.twist.linear.y);
+      } catch (const std::exception & e) {
+        std::cerr << e.what() << '\n';
+      }
+    } else if (is_detection) {
+      try {
+        rclcpp::SerializedMessage sm(*message->message->serialized_data);
+        marine_acoustic_msgs::msg::SonarDetections detections;
+        rclcpp::Serialization<marine_acoustic_msgs::msg::SonarDetections>().deserialize_message(
+          &sm, &detections);
+        const int64_t ping_ns = static_cast<int64_t>(detections.header.stamp.sec) * 1000000000LL +
+          detections.header.stamp.nanosec;
+        pending.emplace_back(ping_ns, std::move(detections));
       } catch (const std::exception & e) {
         std::cerr << e.what() << '\n';
       }
     }
 
-    if (ping_count_limit > 0 && ping_count >= ping_count_limit) {
-      std::cout << "\nPing count limit of " << ping_count_limit << " reached" << std::endl;
-      break;
+    auto now = std::chrono::system_clock::now();
+    if (now >= last_report_time + report_interval && total_ns > 0 &&
+      tf_frontier_ns != std::numeric_limits<int64_t>::min())
+    {
+      double progress = (tf_frontier_ns - begin_ns) / static_cast<double>(total_ns);
+      std::cout << "\r  " << static_cast<int>(100 * progress) << "%  " << ping_count
+                << " pings (" << proj_dropped_georef << " dropped, " << pending.size()
+                << " pending)      " << std::flush;
+      last_report_time = now;
     }
   }
+  // Flush detections still pending at end-of-stream against available coverage.
+  drain_pending(true);
+  if (limit_reached) {
+    std::cout << "\nPing count limit of " << ping_count_limit << " reached" << std::endl;
+  }
+  std::cout << "\n  buffered " << tf_count << " transforms";
+  if (!odom_topic.empty()) {std::cout << ", " << speed_by_ns.size() << " odometry samples";}
+  std::cout << "; projected " << ping_count << " pings in " << phase_secs() << "s." << std::endl;
 
   std::cout << "\ndone." << std::endl;
-  std::cout << "Offline projection: " << proj_pings << " pings, " << proj_soundings
-            << " soundings (" << proj_filtered_range << " range-filtered, "
-            << proj_missing_attitude << " missing attitude, " << proj_missing_heave
-            << " missing heave)" << std::endl;
+  std::cout << "Offline projection: " << proj_pings << " pings projected, "
+            << ping_count << " georeferenced into the grid, " << proj_dropped_georef
+            << " dropped (no earth TF); " << proj_soundings << " soundings ("
+            << proj_filtered_range << " range-filtered, " << proj_missing_attitude
+            << " missing attitude, " << proj_missing_heave << " missing heave)" << std::endl;
   if (proj_pings > 0 && proj_soundings == 0) {
     std::cerr << "WARNING: projected 0 soundings from " << proj_pings
               << " pings -- check the --*-frame overrides match the bag's "
               << "namespaced frames (see README 'Configuring frames per platform')."
+              << std::endl;
+  }
+  if (ping_count == 0 && proj_dropped_georef > 0) {
+    std::cerr << "WARNING: every ping was dropped for lack of an earth transform -- "
+              << "check that the bag has a localization chain to the 'earth' frame."
               << std::endl;
   }
 
@@ -496,7 +657,8 @@ int main(int argc, char * argv[])
   const uint16_t source_index = registry.registerSource(source_record);
 
   auto tiles = cube::mapSheetToEpochTiles(geo_map_sheet, cell_timestamp_ns, source_index);
-  std::cout << "Tiles with data: " << tiles.size() << std::endl;
+  std::cout << "Tiles with data: " << tiles.size() << " (build: " << phase_secs() << "s)"
+            << std::endl;
 
   if (tiles.empty()) {
     std::cerr << "WARNING: no tiles had finite data -- nothing imported. Check "

--- a/cube_bathymetry/src/node.cpp
+++ b/cube_bathymetry/src/node.cpp
@@ -122,7 +122,13 @@ bool Node::insert(double distance, const Sounding & sounding, const Parameters &
     return false;
   }
 
-  distance += CONF_95PC * std::sqrt(sounding.horizontal_error);
+  // Defensive: a non-finite horizontal_error (e.g. an upstream TPU gap) must not
+  // poison `distance` -> the depth `variance` below -> the whole estimate -> an
+  // empty epoch (cube_bathymetry#63). Skip the horizontal term if it isn't finite
+  // rather than NaN-propagating into the depth solution.
+  if (std::isfinite(sounding.horizontal_error)) {
+    distance += CONF_95PC * std::sqrt(sounding.horizontal_error);
+  }
 
   float offset = 0.0;
   double variance = sounding.vertical_error * (1.0 + parameters.variance_scale * pow(distance,

--- a/cube_bathymetry/test/test_error_model.cpp
+++ b/cube_bathymetry/test/test_error_model.cpp
@@ -21,6 +21,7 @@
 
 #include <gtest/gtest.h>
 #include <cmath>
+#include <limits>
 #include <vector>
 #include "cube_bathymetry/error_model.h"
 #include "cube_bathymetry/parameters.h"
@@ -142,6 +143,39 @@ TEST_F(ErrorModelTest, HorizontalErrorIsInsensitiveToVesselSpeedSign)
   // And the speed path is genuinely exercised: nonzero speed adds latency error
   // on top of the zero-speed baseline (otherwise the equality above is vacuous).
   EXPECT_GT(s_pos[0].horizontal_error, s_zero[0].horizontal_error);
+}
+
+// Regression for the offline-import empty-epoch bug (cube_bathymetry#63): a
+// non-finite vessel_speed (offline replay supplies NaN; a corrupt odom twist
+// could yield +/-inf) must floor to 0 rather than NaN/inf-poisoning
+// horizontal_error -- which propagates through Node::insert into the depth
+// variance and zeroes the whole epoch. The floored result is finite and equals
+// the zero-speed baseline.
+TEST_F(ErrorModelTest, HorizontalErrorFloorsNonFiniteVesselSpeed)
+{
+  ErrorModel em(vessel, device);
+  auto det = makeDetections({0.0f}, 0.02f);  // nadir → speed terms maximal
+
+  auto p_nan = makePlatform();
+  p_nan.vessel_speed = std::numeric_limits<float>::quiet_NaN();
+  auto p_inf = makePlatform();
+  p_inf.vessel_speed = std::numeric_limits<float>::infinity();
+  auto p_zero = makePlatform();
+  p_zero.vessel_speed = 0.0f;
+
+  auto s_nan = em.compute(det, p_nan);
+  auto s_inf = em.compute(det, p_inf);
+  auto s_zero = em.compute(det, p_zero);
+  ASSERT_EQ(s_nan.size(), 1u);
+  ASSERT_EQ(s_inf.size(), 1u);
+  ASSERT_EQ(s_zero.size(), 1u);
+
+  // Non-finite speed floors to 0: finite horizontal_error equal to the zero-speed
+  // baseline (not NaN/inf, which would zero the epoch downstream).
+  EXPECT_TRUE(std::isfinite(s_nan[0].horizontal_error));
+  EXPECT_TRUE(std::isfinite(s_inf[0].horizontal_error));
+  EXPECT_FLOAT_EQ(s_nan[0].horizontal_error, s_zero[0].horizontal_error);
+  EXPECT_FLOAT_EQ(s_inf[0].horizontal_error, s_zero[0].horizontal_error);
 }
 
 TEST_F(ErrorModelTest, VerticalErrorIncreasesWithBeamAngle)


### PR DESCRIPTION
## Summary

Makes the offline M3 → bathymetry-store importer (`import_bag`, #57) actually
produce tiles, and takes the full-bag import from **~12 h to ~4.2 min**.

Validated on the 06-12 Massabesic pre-survey M3 bag (351,545 detections, 5.3 h):
imports in **251.6 s**, 1 ping dropped (the first, before the earth fix), 80.9 M
soundings → 4 tiles, depth band 41–48 m (ellipsoidal; lake datum ~52 m).

## What was wrong

1. **Empty epochs (Fix A).** Offline replay supplies `vessel_speed = NaN`. The
   horizontal-TPU terms used it directly past a *dead* guard, so the NaN flowed
   through `horizontal_error` → `Node::insert` capture distance
   (`sqrt(horizontal_error)`) → depth variance → NaN estimate → **zero finite
   tiles**.
2. **~12 h import.** The two-pass design buffered the whole bag's TF (~1.15 M
   transforms) before projecting. tf2's `TimeCache` is a `std::list` walked
   linearly by `findClosest`, so **every `lookupTransform` was an O(n) walk**
   (~53 ms each; worse for early-bag pings far from the list's newest end).
   `project()`'s 2 internal lookups + the georef lookup = the whole cost; the
   per-sounding ECEF→geodetic solves were a red herring (`addSoundings` ≈
   0.4 ms/ping).

## Changes

- **Fix A** (`error_model.cpp`, `node.cpp`): floor non-finite/negative speed to
  0 in one guarded local used by all speed-dependent terms; defensively skip the
  capture-distance term when `horizontal_error` isn't finite. Defense in depth.
- **Single interleaved pass + bounded 60 s TF cache** (`import_bag_main.cpp`):
  read messages chronologically, feed TF into a bounded buffer, and hold each
  detection in a FIFO until the TF frontier advances a **3 s guard** past its
  stamp — so both bracketing transforms are present (the correctness the 2-pass
  bought) while the per-frame cache stays short and lookups land near its newest
  end. Lookups: ~53 ms → ~5 µs. **0 frontier drops** on real data.
- **Per-ping ENU georef**: convert the sensor-origin ECEF→lat/long once per ping,
  then map each sounding through a local-ENU tangent plane + first-order
  radii-of-curvature linearization (M/N inline — gz4d `Ellipsoid::M()` is bugged:
  `(1-e²)·sin²φ` vs `1-e²·sin²φ`). Verified bit-equivalent (43.1–43.8 m on a
  bounded run, identical to the prior iterative path). Speeds the live node too.
- **Fix B**: `--odom-topic` supplies per-ping speed-over-ground (`speedAt`,
  nearest with a 5 s max-age so an odom dropout floors to 0 rather than applying
  stale speed).
- **Equirectangular cell distance** (`geo_grid.cpp`): drop the per-cell WGS84
  Vincenty inverse the #144 refactor introduced (sub-mm at these radii).
- **Diagnostics**: `TransformException` now counts `proj_dropped_georef` (capped
  stderr + an all-dropped warning) instead of silently dropping pings.
- **Build**: default `CMAKE_BUILD_TYPE` to `RelWithDebInfo` when unset (colcon
  defaults to `-O0`); link `nav_msgs`; drop the now-unused `geodesy` dep.

## Testing

- `colcon test` cube_bathymetry: **300 tests, 0 failures**.
- Full 06-12 import + bounded re-runs: 0 frontier drops, depths verified.
- Ran `/review-code` (8 finder angles + verify) on the diff; fixed dead
  `bag_filter`/`geodesy`, hardened the speed guard to `!isfinite` (catches +inf),
  and added the `speedAt` max-age.

## Known follow-ups (not blocking)

- `bag_to_geotiff` still uses the old per-sounding iterative georef — a future
  unify-and-test pass would share the linearized helper.
- The drain guard uses a global TF frontier; a hypothetical low-rate earth-chain
  frame could raise drops, but they're counted/warned and the real data is clean.

Closes #63

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8`
