### PR TITLE
ci: migrate to industrial_ci + ccache (pilot) (#72)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,20 @@ jobs:
           UPSTREAM_WORKSPACE: upstream.repos
           # Activates ccache inside industrial_ci's build.
           CCACHE_DIR: ${{ github.workspace }}/.ccache
+          # --- Upstream-monorepo workarounds (see #72) ---------------------
+          # industrial_ci resolves + builds the WHOLE unh_marine_autonomy
+          # monorepo, unlike the old `rosdep -r` + `--packages-up-to` flow that
+          # only touched cube's subtree. That surfaces latent packaging gaps in
+          # unh_marine_autonomy which are not cube_bathymetry's concern:
+          #   * `nlohmann_json` is not a valid rosdep key (should be
+          #     `nlohmann-json-dev`); cube needs it via marine_bathymetry_store,
+          #     so we skip the bad key and install the deb directly.
+          #   * mission_manager*/integration-tests/backscatter depend on
+          #     marine_nav_* (a repo not in upstream.repos) and are unrelated to
+          #     cube — COLCON_IGNORE them so the upstream build does not pull a
+          #     dependency cube never uses.
+          # Proper fix belongs upstream (correct rosdep keys + declare marine_nav
+          # deps); tracked separately. Revisit this block when that lands.
+          ROSDEP_SKIP_KEYS: "nlohmann_json marine_nav_interfaces marine_nav_tasks"
+          ADDITIONAL_DEBS: "nlohmann-json3-dev"
+          AFTER_SETUP_UPSTREAM_WORKSPACE: 'for p in mission_manager mission_manager_interfaces marine_autonomy_integration_tests marine_mbes_backscatter_store; do find /root/upstream_ws/src -type d -name "$p" -exec touch {}/COLCON_IGNORE \; ; done'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,63 +7,39 @@ on:
     branches: [jazzy]
 
 jobs:
-  build-and-test:
+  industrial_ci:
+    name: ROS 2 Jazzy (industrial_ci)
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    container:
-      image: ros:jazzy-ros-core
 
     steps:
-      - name: Update apt
-        run: apt-get update
-
-      - name: Install ros dev tools
-        run: DEBIAN_FRONTEND=noninteractive apt-get -y install ros-dev-tools
-
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Init rosdep
-        run: rosdep init
+      # Persist the ccache across runs so unchanged upstream packages
+      # (unh_marine_autonomy, mru_transform, ...) recompile near-incrementally
+      # instead of from scratch. Keyed per-commit, restored from any prior run.
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: ccache-jazzy-${{ github.sha }}
+          restore-keys: |
+            ccache-jazzy-
 
-      - name: Update rosdep
-        run: rosdep update
-
-      - name: Create workspace
-        run: mkdir -p ../ws/src && ln -s $GITHUB_WORKSPACE ../ws/src/cube_bathymetry
-
-      - name: Clone unreleased dependencies
-        run: |
-          git clone --depth 1 -b jazzy https://github.com/rolker/unh_marine_autonomy.git ../ws/src/unh_marine_autonomy
-          git clone --depth 1 -b jazzy https://github.com/rolker/mru_transform.git ../ws/src/mru_transform
-          git clone --depth 1 -b ros2 https://github.com/ros-geographic-info/geographic_info.git ../ws/src/geographic_info
-
-      - name: Install ROS dependencies
-        working-directory: ../ws
-        run: >
-          DEBIAN_FRONTEND=noninteractive
-          rosdep install --from-paths src --ignore-src -r -y
-
-      - name: Build
-        working-directory: ../ws
-        run: >
-          bash -c 'source /opt/ros/jazzy/setup.bash &&
-          colcon build --packages-up-to cube_bathymetry
-          --cmake-args -DBUILD_TESTING=ON'
-
-      - name: Test
-        working-directory: ../ws
-        run: >
-          bash -c 'source /opt/ros/jazzy/setup.bash &&
-          source install/setup.bash &&
-          colcon test --packages-select cube_bathymetry
-          --event-handlers console_direct+
-          --return-code-on-test-failure'
-
-      - name: Test results
-        working-directory: ../ws
-        run: >
-          bash -c 'source /opt/ros/jazzy/setup.bash &&
-          colcon test-result --verbose'
-        if: always()
+      # ros-industrial/industrial_ci runs the full ROS pipeline in a container:
+      # rosdep resolve -> build the upstream workspace + this package -> colcon
+      # test (incl. the ament linters). The same invocation reproduces locally
+      # (`run_ci` / .ci entrypoint), so CI lint versions can be matched on a dev
+      # machine before pushing.
+      - name: industrial_ci
+        uses: ros-industrial/industrial_ci@master
+        env:
+          ROS_DISTRO: jazzy
+          ROS_REPO: main
+          # Unreleased source deps, cloned by industrial_ci into the upstream
+          # workspace (replaces the manual git-clone step).
+          UPSTREAM_WORKSPACE: upstream.repos
+          # Activates ccache inside industrial_ci's build.
+          CCACHE_DIR: ${{ github.workspace }}/.ccache

--- a/upstream.repos
+++ b/upstream.repos
@@ -1,0 +1,16 @@
+# Unreleased source dependencies for cube_bathymetry CI, cloned by
+# industrial_ci (UPSTREAM_WORKSPACE) into the upstream workspace and built
+# before this package. Mirrors the deps the previous hand-rolled CI cloned.
+repositories:
+  unh_marine_autonomy:
+    type: git
+    url: https://github.com/rolker/unh_marine_autonomy.git
+    version: jazzy
+  mru_transform:
+    type: git
+    url: https://github.com/rolker/mru_transform.git
+    version: jazzy
+  geographic_info:
+    type: git
+    url: https://github.com/ros-geographic-info/geographic_info.git
+    version: ros2


### PR DESCRIPTION
## Summary

Pilot: migrate `cube_bathymetry` CI from the hand-rolled cold-rebuild workflow to
[`ros-industrial/industrial_ci`](https://github.com/ros-industrial/industrial_ci)
with **ccache**. If it pays off, this becomes the per-repo CI template.

Closes #72.

## What changed

- **`.github/workflows/ci.yml`** — replaced the 7 manual steps (apt/dev-tools,
  rosdep init/update, manual clones, rosdep install, build, test) with a single
  `industrial_ci` step (`ROS_DISTRO=jazzy`, `ROS_REPO=main`,
  `UPSTREAM_WORKSPACE=upstream.repos`), plus an `actions/cache` step persisting
  `ccache`.
- **`upstream.repos`** (new) — the three unreleased deps previously cloned by
  hand (`unh_marine_autonomy`@jazzy, `mru_transform`@jazzy, `geographic_info`@ros2),
  now pulled by industrial_ci into the upstream workspace.

## Why

- **ccache across runs** makes the heavy upstream rebuild near-incremental.
- **Local reproduction** — `industrial_ci` runs the same container + linter
  versions locally, so CI lint (e.g. the CI uncrustify version) can be matched on
  a dev machine before pushing. Addresses the recurring local-uncrustify drift.

## Validation

- YAML validated; the live CI run on this PR is the cold-cache baseline. I'll post
  cold vs warm-cache timings (re-run with the cache populated) against the prior
  ~5–6 min baseline before recommending we template this to other repos.

## Notes / follow-ups

- `industrial_ci@master` is unpinned (community convention); we can pin to a SHA
  for reproducibility if preferred.
- A custom pre-baked deps image (`DOCKER_IMAGE`) to also remove the per-run rosdep
  apt install is a possible Tier-C follow-up if rosdep install dominates after ccache.

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8`
